### PR TITLE
Correctly skip out-of-bound tiles for dynamic add kernel

### DIFF
--- a/examples/aot/add_dynamic_multicore/add_builder.py
+++ b/examples/aot/add_dynamic_multicore/add_builder.py
@@ -67,26 +67,62 @@ def build():
                 tb1 = pto.AllocTileOp(tile_buf).result
                 tb2 = pto.AllocTileOp(tile_buf).result
 
-                # NOTE: `scf.for_` syntax sugar defined in https://github.com/llvm/llvm-project/blob/llvmorg-19.1.7/mlir/python/mlir/dialects/scf.py#L106
-                for i in scf.for_(c0, num_tiles_per_core, c1):
-                    tile_offset_global = arith.AddIOp(i, tile_offset_this_core).result
-                    offset_global = arith.MulIOp(tile_offset_global, c_tile).result
-
-                    sv0 = pto.PartitionViewOp(
-                        tile_view, tv0, offsets=[offset_global], sizes=[c_tile]
+                # Skip whole core if its starting tile is already out-of-bound.
+                has_valid_start_tile = arith.CmpIOp(
+                    arith.CmpIPredicate.slt, tile_offset_this_core, num_tiles_global
+                ).result
+                core_if = scf.IfOp(has_valid_start_tile)
+                with InsertionPoint(core_if.then_block):
+                    tiles_end_this_core = arith.AddIOp(
+                        tile_offset_this_core, num_tiles_per_core
                     ).result
-                    sv1 = pto.PartitionViewOp(
-                        tile_view, tv1, offsets=[offset_global], sizes=[c_tile]
+                    need_truncate = arith.CmpIOp(
+                        arith.CmpIPredicate.sgt, tiles_end_this_core, num_tiles_global
                     ).result
-                    sv2 = pto.PartitionViewOp(
-                        tile_view, tv2, offsets=[offset_global], sizes=[c_tile]
+                    remaining_tiles = arith.SubIOp(
+                        num_tiles_global, tile_offset_this_core
                     ).result
 
-                    pto.TLoadOp(None, sv0, tb0)
-                    pto.TLoadOp(None, sv1, tb1)
-                    pto.TAddOp(tb0, tb1, tb2)
-                    pto.TStoreOp(None, tb2, sv2)
+                    # Truncate per-core tiles when the chunk crosses global bound.
+                    tiles_to_process_if = scf.IfOp(
+                        need_truncate, [IndexType.get()], hasElse=True
+                    )
+                    with InsertionPoint(tiles_to_process_if.then_block):
+                        scf.YieldOp([remaining_tiles])
+                    with InsertionPoint(tiles_to_process_if.else_block):
+                        scf.YieldOp([num_tiles_per_core])
+                    tiles_to_process = tiles_to_process_if.results[0]
 
+                    elements_to_process = arith.MulIOp(tiles_to_process, c_tile).result
+                    has_elements = arith.CmpIOp(
+                        arith.CmpIPredicate.sgt, elements_to_process, c0
+                    ).result
+                    work_if = scf.IfOp(has_elements)
+                    with InsertionPoint(work_if.then_block):
+                        # NOTE: `scf.for_` syntax sugar defined in https://github.com/llvm/llvm-project/blob/llvmorg-19.1.7/mlir/python/mlir/dialects/scf.py#L106
+                        for i in scf.for_(c0, tiles_to_process, c1):
+                            tile_offset_global = arith.AddIOp(
+                                i, tile_offset_this_core
+                            ).result
+                            offset_global = arith.MulIOp(tile_offset_global, c_tile).result
+
+                            sv0 = pto.PartitionViewOp(
+                                tile_view, tv0, offsets=[offset_global], sizes=[c_tile]
+                            ).result
+                            sv1 = pto.PartitionViewOp(
+                                tile_view, tv1, offsets=[offset_global], sizes=[c_tile]
+                            ).result
+                            sv2 = pto.PartitionViewOp(
+                                tile_view, tv2, offsets=[offset_global], sizes=[c_tile]
+                            ).result
+
+                            pto.TLoadOp(None, sv0, tb0)
+                            pto.TLoadOp(None, sv1, tb1)
+                            pto.TAddOp(tb0, tb1, tb2)
+                            pto.TStoreOp(None, tb2, sv2)
+
+                            scf.YieldOp([])
+                        scf.YieldOp([])
                     scf.YieldOp([])
 
             func.ReturnOp([])

--- a/examples/aot/add_dynamic_multicore/run_add.py
+++ b/examples/aot/add_dynamic_multicore/run_add.py
@@ -40,8 +40,10 @@ def test_add():
     # shape parameter hard-coded as kernel
     num_cores = 20 * 2
     tile_size = 1024
-    expected_iters = [1, 2, 3, 5, 9]
-    shape_list = [tile_size * num_cores * iters for iters in expected_iters]
+    # Keep shapes aligned to tile size, but vary tile counts so they are not
+    # required to be multiples of `num_cores`.
+    tile_counts = [1, 7, num_cores - 1, num_cores + 3, 2 * num_cores + 7, 5 * num_cores - 5]
+    shape_list = [tile_size * tiles for tiles in tile_counts]
 
     torch.manual_seed(0)
     dtype = torch.float32


### PR DESCRIPTION
Generalize dynamic add's input shape to any multiples of `c_tile = 1024`, but no need to be multiples of `c_tile * num_cores`

Output:

```
python ./run_add.py 
result equal for shape 1024
result equal for shape 7168
result equal for shape 39936
result equal for shape 44032
result equal for shape 89088
result equal for shape 199680
```

Todo
- [x] Generalize non-multiple of `c_tile = 1024` by valid_shape masking; done by https://github.com/huawei-csl/pto-dsl/pull/12

## The prompt for reference

This PR is largely generated by Cursor (GPT-5.3 codex backend) with the prompt below:

Near @examples/aot/add_dynamic_multicore/add_builder.py:54-57 and @examples/aot/add_dynamic_multicore/add_builder.py:71-73 , use MLIR scf.IfOp to limit the numbers of iterations for out-of-bound cases. The pseudo code logic is like:

```python
if tile_offset_this_core >= num_tiles_global:
    return  # this core has no valid data to process, do nothing

tiles_to_process = num_tiles_per_core;
if tile_offset_this_core + num_tiles_per_core > num_tiles_global:
    tiles_to_process = num_tiles_global - tile_offset_this_core  # truncate out-of-bound tiles, only process from current offset until `num_tiles_global`

if elements_to_process == 0:
    return  # do nothing if truncated data has no elements left
```

Note that MLIR func dialect can only have a single return at @examples/aot/add_dynamic_multicore/add_builder.py:92 . You need to change the early-return pattern to valid scf control blocks.

See the documentation of MLIR scf dialect in https://mlir.llvm.org/python-bindings/autoapi/mlir/dialects/scf/index.html  and the example  usage in https://github.com/llvm/llvm-project/blob/llvmorg-19.1.7/mlir/test/python/dialects/scf.py . For branching, you need `arith.cmpi` documented in https://mlir.llvm.org/python-bindings/autoapi/mlir/dialects/arith/index.html#mlir.dialects.arith.CmpIOp 
