### PR TITLE
try remove explicit sync in matmul and use ptoas auto-sync

### DIFF
--- a/examples/aot/matmul_static_singlecore/compile.sh
+++ b/examples/aot/matmul_static_singlecore/compile.sh
@@ -1,7 +1,7 @@
 rm matmul.pto matmul.cpp matmul_kernel.so
 
 python ./matmul_builder.py > matmul.pto
-ptoas matmul.pto -o matmul.cpp
+ptoas --enable-insert-sync matmul.pto -o matmul.cpp
 
 bisheng -fPIC -shared -xcce -O2 -std=c++17 \
     --npu-arch=dav-2201 -DMEMORY_BASE \


### PR DESCRIPTION
kernel dead-locks. just commit to show the bug.

Complete logs (7k lines) from `ptoas --enable-insert-sync matmul.pto 2>ptoas_sync.log`
[ptoas_sync.log](https://github.com/user-attachments/files/25366214/ptoas_sync.log)

## Reference output

1. Generated cpp from `ptoas --enable-insert-sync`. It uses up to `EVENT_ID5`. This is too much compared to manual sync that only uses `EVENT_ID0`

<details>

```cpp
#include "pto/pto-inst.hpp"
using namespace pto;

	template <typename To, typename From>
	static inline To ptoas_bitcast(From from) {
	  static_assert(sizeof(To) == sizeof(From), "ptoas_bitcast: size mismatch");
	  To to;
	  __builtin_memcpy(&to, &from, sizeof(To));
	  return to;
	}
	
__global__ AICORE void RunTMATMULSplitK(__gm__ float* v1, __gm__ float* v2, __gm__ float* v3, __gm__ float* v4, bool v5) {
  int64_t v6;
  int64_t v7;
  int64_t v8;
  int32_t v9;
  size_t v10;
  int32_t v11;
  int32_t v12;
  int32_t v13;
  size_t v14;
  int32_t v15;
  size_t v16;
  Tile<TileType::Mat, float, 32, 32, BLayout::ColMajor, 32, 32, SLayout::RowMajor, 512, PadValue::Null> v17;
  Tile<TileType::Mat, float, 32, 32, BLayout::ColMajor, 32, 32, SLayout::RowMajor, 512, PadValue::Null> v18;
  Tile<TileType::Mat, float, 1, 32, BLayout::RowMajor, 1, 32, SLayout::NoneBox, 512, PadValue::Null> v19;
  Tile<TileType::Left, float, 32, 32, BLayout::RowMajor, 32, 32, SLayout::RowMajor, 512, PadValue::Null> v20;
  Tile<TileType::Right, float, 32, 32, BLayout::RowMajor, 32, 32, SLayout::ColMajor, 512, PadValue::Null> v21;
  Tile<TileType::Acc, float, 32, 32, BLayout::ColMajor, 32, 32, SLayout::RowMajor, 1024, PadValue::Null> v22;
  Tile<TileType::Bias, float, 1, 32, BLayout::RowMajor, 1, 32, SLayout::NoneBox, 512, PadValue::Null> v23;
  int32_t v24;
  uint32_t v25;
  uint32_t v26;
  uint32_t v27;
  int32_t v28;
  unsigned v29;
  unsigned v30;
  unsigned v31;
  unsigned v32;
  unsigned v33;
  unsigned v34;
  unsigned v35;
  unsigned v36;
  unsigned v37;
  unsigned v38;
  unsigned v39;
  __gm__ float* v40;
  pto::Shape<1, 1, 1, 32, 32> v41;
  pto::Stride<8192, 8192, 8192, 256, 1> v42;
  GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<8192, 8192, 8192, 256, 1>, pto::Layout::ND> v43(nullptr);
  unsigned v44;
  unsigned v45;
  unsigned v46;
  unsigned v47;
  unsigned v48;
  unsigned v49;
  unsigned v50;
  unsigned v51;
  unsigned v52;
  unsigned v53;
  unsigned v54;
  __gm__ float* v55;
  pto::Shape<1, 1, 1, 32, 32> v56;
  pto::Stride<1024, 1024, 1024, 32, 1> v57;
  GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND> v58(nullptr);
  unsigned v59;
  unsigned v60;
  unsigned v61;
  unsigned v62;
  unsigned v63;
  unsigned v64;
  unsigned v65;
  unsigned v66;
  unsigned v67;
  unsigned v68;
  unsigned v69;
  __gm__ float* v70;
  pto::Shape<1, 1, 1, 1, 32> v71;
  pto::Stride<32, 32, 32, 32, 1> v72;
  GlobalTensor<float, pto::Shape<1, 1, 1, 1, 32>, pto::Stride<32, 32, 32, 32, 1>, pto::Layout::ND> v73(nullptr);
  bool v74;
  unsigned v75;
  unsigned v76;
  unsigned v77;
  unsigned v78;
  unsigned v79;
  unsigned v80;
  unsigned v81;
  unsigned v82;
  unsigned v83;
  unsigned v84;
  unsigned v85;
  __gm__ float* v86;
  pto::Shape<1, 1, 1, 32, 32> v87;
  pto::Stride<1024, 1024, 1024, 32, 1> v88;
  GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND> v89(nullptr);
  using T = float;
  v6 = 8192;
  v7 = 4096;
  v8 = 0;
  v9 = 8;
  v10 = (size_t) v9;
  v11 = 256;
  v12 = 32;
  v13 = 1;
  v14 = (size_t) v13;
  v15 = 0;
  v16 = (size_t) v15;

  #if defined(__DAV_CUBE__)
  ;
  TASSIGN(v17, v8);
  ;
  TASSIGN(v18, v7);
  ;
  TASSIGN(v19, v6);
  ;
  TASSIGN(v20, v8);
  ;
  TASSIGN(v21, v8);
  ;
  TASSIGN(v22, v8);
  ;
  TASSIGN(v23, v8);
  set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID0);
  set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID1);
  set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID2);
  set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
  set_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
  set_flag(PIPE_M, PIPE_MTE1, EVENT_ID2);
  for (size_t v90 = v16; v90 < v10; v90 += v14) {
    v24 = (int32_t) v90;
    v25 = (uint32_t) v24;
    v26 = (uint32_t) v12;
    v27 = v25 * v26;
    v28 = (int32_t) v27;
    v29 = 0;
    v30 = 0;
    v31 = 1;
    v32 = (unsigned) v11;
    v33 = v30 * v32;
    v34 = v29 + v33;
    v35 = (unsigned) v28;
    v36 = 1;
    v37 = (unsigned) v13;
    v38 = v35 * v37;
    v39 = v34 + v38;
    v40 = v2 + v39;
    v41 = pto::Shape<1, 1, 1, 32, 32>();
    v42 = pto::Stride<8192, 8192, 8192, 256, 1>();
    v43 = GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<8192, 8192, 8192, 256, 1>, pto::Layout::ND>(v40, v41, v42);
    v44 = 0;
    v45 = (unsigned) v28;
    v46 = 1;
    v47 = (unsigned) v12;
    v48 = v45 * v47;
    v49 = v44 + v48;
    v50 = 0;
    v51 = 1;
    v52 = (unsigned) v13;
    v53 = v50 * v52;
    v54 = v49 + v53;
    v55 = v3 + v54;
    v56 = pto::Shape<1, 1, 1, 32, 32>();
    v57 = pto::Stride<1024, 1024, 1024, 32, 1>();
    v58 = GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND>(v55, v56, v57);
    v59 = 0;
    v60 = 0;
    v61 = 1;
    v62 = (unsigned) v12;
    v63 = v60 * v62;
    v64 = v59 + v63;
    v65 = 0;
    v66 = 1;
    v67 = (unsigned) v13;
    v68 = v65 * v67;
    v69 = v64 + v68;
    v70 = v4 + v69;
    v71 = pto::Shape<1, 1, 1, 1, 32>();
    v72 = pto::Stride<32, 32, 32, 32, 1>();
    v73 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 32>, pto::Stride<32, 32, 32, 32, 1>, pto::Layout::ND>(v70, v71, v72);
    wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID0);
    TLOAD(v17, v43);
    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);
    wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID1);
    TLOAD(v18, v58);
    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID2);
    wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID2);
    if (v5) {
      TLOAD(v19, v73);
      set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
    } else {
      set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
    };
    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);
    wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
    wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
    wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID2);
    TMOV(v20, v17);
    set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID0);
    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID2);
    TMOV(v21, v18);
    set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID1);
    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID4);
    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
    if (v5) {
      TMOV(v23, v19);
      set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID2);
      set_flag(PIPE_MTE1, PIPE_M, EVENT_ID3);
    } else {
      set_flag(PIPE_MTE1, PIPE_M, EVENT_ID3);
      set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID2);
    };
    v74 = v24 == v15;
    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID3);
    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID4);
    if (v74) {
      if (v5) {
        TMATMUL_BIAS(v22, v20, v21, v23);
        set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
        set_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
        set_flag(PIPE_M, PIPE_FIX, EVENT_ID3);
      } else {
        TMATMUL(v22, v20, v21);
        set_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
        set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
        set_flag(PIPE_M, PIPE_FIX, EVENT_ID4);
      };
      set_flag(PIPE_M, PIPE_MTE1, EVENT_ID2);
      set_flag(PIPE_M, PIPE_FIX, EVENT_ID5);
    } else {
      TMATMUL_ACC(v22, v22, v20, v21);
      set_flag(PIPE_M, PIPE_MTE1, EVENT_ID2);
      set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
      set_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
      set_flag(PIPE_M, PIPE_FIX, EVENT_ID4);
      set_flag(PIPE_M, PIPE_FIX, EVENT_ID3);
    };
  }
  set_flag(PIPE_M, PIPE_FIX, EVENT_ID5);
  set_flag(PIPE_M, PIPE_FIX, EVENT_ID3);
  set_flag(PIPE_M, PIPE_FIX, EVENT_ID4);
  v75 = 0;
  v76 = 0;
  v77 = 1;
  v78 = (unsigned) v12;
  v79 = v76 * v78;
  v80 = v75 + v79;
  v81 = 0;
  v82 = 1;
  v83 = (unsigned) v13;
  v84 = v81 * v83;
  v85 = v80 + v84;
  v86 = v1 + v85;
  v87 = pto::Shape<1, 1, 1, 32, 32>();
  v88 = pto::Stride<1024, 1024, 1024, 32, 1>();
  v89 = GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND>(v86, v87, v88);
  wait_flag(PIPE_M, PIPE_FIX, EVENT_ID4);
  wait_flag(PIPE_M, PIPE_FIX, EVENT_ID3);
  wait_flag(PIPE_M, PIPE_FIX, EVENT_ID5);
  TSTORE(v89, v22);
  pipe_barrier(PIPE_ALL);
  wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID0);
  wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID1);
  wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID2);
  wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
  wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
  wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID2);
  #endif // __DAV_CUBE__

  return;
}
```

</details>

2. Generated cpp before this commit, from https://github.com/huawei-csl/pto-dsl/pull/13

<details>

```cpp
#include "pto/pto-inst.hpp"
using namespace pto;

	template <typename To, typename From>
	static inline To ptoas_bitcast(From from) {
	  static_assert(sizeof(To) == sizeof(From), "ptoas_bitcast: size mismatch");
	  To to;
	  __builtin_memcpy(&to, &from, sizeof(To));
	  return to;
	}
	
__global__ AICORE void RunTMATMULSplitK(__gm__ float* v1, __gm__ float* v2, __gm__ float* v3, __gm__ float* v4, bool v5) {
  int64_t v6;
  int64_t v7;
  int64_t v8;
  int32_t v9;
  size_t v10;
  int32_t v11;
  int32_t v12;
  int32_t v13;
  size_t v14;
  int32_t v15;
  size_t v16;
  Tile<TileType::Mat, float, 32, 32, BLayout::ColMajor, 32, 32, SLayout::RowMajor, 512, PadValue::Null> v17;
  Tile<TileType::Mat, float, 32, 32, BLayout::ColMajor, 32, 32, SLayout::RowMajor, 512, PadValue::Null> v18;
  Tile<TileType::Mat, float, 1, 32, BLayout::RowMajor, 1, 32, SLayout::NoneBox, 512, PadValue::Null> v19;
  Tile<TileType::Left, float, 32, 32, BLayout::RowMajor, 32, 32, SLayout::RowMajor, 512, PadValue::Null> v20;
  Tile<TileType::Right, float, 32, 32, BLayout::RowMajor, 32, 32, SLayout::ColMajor, 512, PadValue::Null> v21;
  Tile<TileType::Acc, float, 32, 32, BLayout::ColMajor, 32, 32, SLayout::RowMajor, 1024, PadValue::Null> v22;
  Tile<TileType::Bias, float, 1, 32, BLayout::RowMajor, 1, 32, SLayout::NoneBox, 512, PadValue::Null> v23;
  int32_t v24;
  uint32_t v25;
  uint32_t v26;
  uint32_t v27;
  int32_t v28;
  unsigned v29;
  unsigned v30;
  unsigned v31;
  unsigned v32;
  unsigned v33;
  unsigned v34;
  unsigned v35;
  unsigned v36;
  unsigned v37;
  unsigned v38;
  unsigned v39;
  __gm__ float* v40;
  pto::Shape<1, 1, 1, 32, 32> v41;
  pto::Stride<8192, 8192, 8192, 256, 1> v42;
  GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<8192, 8192, 8192, 256, 1>, pto::Layout::ND> v43(nullptr);
  unsigned v44;
  unsigned v45;
  unsigned v46;
  unsigned v47;
  unsigned v48;
  unsigned v49;
  unsigned v50;
  unsigned v51;
  unsigned v52;
  unsigned v53;
  unsigned v54;
  __gm__ float* v55;
  pto::Shape<1, 1, 1, 32, 32> v56;
  pto::Stride<1024, 1024, 1024, 32, 1> v57;
  GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND> v58(nullptr);
  unsigned v59;
  unsigned v60;
  unsigned v61;
  unsigned v62;
  unsigned v63;
  unsigned v64;
  unsigned v65;
  unsigned v66;
  unsigned v67;
  unsigned v68;
  unsigned v69;
  __gm__ float* v70;
  pto::Shape<1, 1, 1, 1, 32> v71;
  pto::Stride<32, 32, 32, 32, 1> v72;
  GlobalTensor<float, pto::Shape<1, 1, 1, 1, 32>, pto::Stride<32, 32, 32, 32, 1>, pto::Layout::ND> v73(nullptr);
  bool v74;
  unsigned v75;
  unsigned v76;
  unsigned v77;
  unsigned v78;
  unsigned v79;
  unsigned v80;
  unsigned v81;
  unsigned v82;
  unsigned v83;
  unsigned v84;
  unsigned v85;
  __gm__ float* v86;
  pto::Shape<1, 1, 1, 32, 32> v87;
  pto::Stride<1024, 1024, 1024, 32, 1> v88;
  GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND> v89(nullptr);
  using T = float;
  v6 = 8192;
  v7 = 4096;
  v8 = 0;
  v9 = 8;
  v10 = (size_t) v9;
  v11 = 256;
  v12 = 32;
  v13 = 1;
  v14 = (size_t) v13;
  v15 = 0;
  v16 = (size_t) v15;

  #if defined(__DAV_CUBE__)
  ;
  TASSIGN(v17, v8);
  ;
  TASSIGN(v18, v7);
  ;
  TASSIGN(v19, v6);
  ;
  TASSIGN(v20, v8);
  ;
  TASSIGN(v21, v8);
  ;
  TASSIGN(v22, v8);
  ;
  TASSIGN(v23, v8);
  for (size_t v90 = v16; v90 < v10; v90 += v14) {
    v24 = (int32_t) v90;
    v25 = (uint32_t) v24;
    v26 = (uint32_t) v12;
    v27 = v25 * v26;
    v28 = (int32_t) v27;
    v29 = 0;
    v30 = 0;
    v31 = 1;
    v32 = (unsigned) v11;
    v33 = v30 * v32;
    v34 = v29 + v33;
    v35 = (unsigned) v28;
    v36 = 1;
    v37 = (unsigned) v13;
    v38 = v35 * v37;
    v39 = v34 + v38;
    v40 = v2 + v39;
    v41 = pto::Shape<1, 1, 1, 32, 32>();
    v42 = pto::Stride<8192, 8192, 8192, 256, 1>();
    v43 = GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<8192, 8192, 8192, 256, 1>, pto::Layout::ND>(v40, v41, v42);
    v44 = 0;
    v45 = (unsigned) v28;
    v46 = 1;
    v47 = (unsigned) v12;
    v48 = v45 * v47;
    v49 = v44 + v48;
    v50 = 0;
    v51 = 1;
    v52 = (unsigned) v13;
    v53 = v50 * v52;
    v54 = v49 + v53;
    v55 = v3 + v54;
    v56 = pto::Shape<1, 1, 1, 32, 32>();
    v57 = pto::Stride<1024, 1024, 1024, 32, 1>();
    v58 = GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND>(v55, v56, v57);
    v59 = 0;
    v60 = 0;
    v61 = 1;
    v62 = (unsigned) v12;
    v63 = v60 * v62;
    v64 = v59 + v63;
    v65 = 0;
    v66 = 1;
    v67 = (unsigned) v13;
    v68 = v65 * v67;
    v69 = v64 + v68;
    v70 = v4 + v69;
    v71 = pto::Shape<1, 1, 1, 1, 32>();
    v72 = pto::Stride<32, 32, 32, 32, 1>();
    v73 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 32>, pto::Stride<32, 32, 32, 32, 1>, pto::Layout::ND>(v70, v71, v72);
    TLOAD(v17, v43);
    TLOAD(v18, v58);
    if (v5) {
      TLOAD(v19, v73);
    } else {
    };
    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
    TMOV(v20, v17);
    TMOV(v21, v18);
    if (v5) {
      TMOV(v23, v19);
    } else {
    };
    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
    v74 = v24 == v15;
    if (v74) {
      if (v5) {
        TMATMUL_BIAS(v22, v20, v21, v23);
      } else {
        TMATMUL(v22, v20, v21);
      };
    } else {
      TMATMUL_ACC(v22, v22, v20, v21);
    };
    set_flag(PIPE_M, PIPE_MTE2, EVENT_ID0);
    wait_flag(PIPE_M, PIPE_MTE2, EVENT_ID0);
  }
  set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
  wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
  v75 = 0;
  v76 = 0;
  v77 = 1;
  v78 = (unsigned) v12;
  v79 = v76 * v78;
  v80 = v75 + v79;
  v81 = 0;
  v82 = 1;
  v83 = (unsigned) v13;
  v84 = v81 * v83;
  v85 = v80 + v84;
  v86 = v1 + v85;
  v87 = pto::Shape<1, 1, 1, 32, 32>();
  v88 = pto::Stride<1024, 1024, 1024, 32, 1>();
  v89 = GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND>(v86, v87, v88);
  TSTORE(v89, v22);
  #endif // __DAV_CUBE__

  return;
}
```

</details>

3. PTO IR from original manual sync frontend, gives to `ptoas` as input:

<details>

```mlir
module attributes {"pto.device-spec" = "Ascend910B1"} {
  func.func @RunTMATMULSplitK(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>, %arg2: !pto.ptr<f32>, %arg3: !pto.ptr<f32>, %arg4: i1) {
    pto.section.cube {
      %c0 = arith.constant 0 : index
      %c1 = arith.constant 1 : index
      %c1_0 = arith.constant 1 : index
      %c32 = arith.constant 32 : index
      %c256 = arith.constant 256 : index
      %c32_1 = arith.constant 32 : index
      %c32_2 = arith.constant 32 : index
      %c8 = arith.constant 8 : index
      %c32_3 = arith.constant 32 : index
      %c32_4 = arith.constant 32 : index
      %0 = pto.make_tensor_view %arg1, shape = [%c32, %c256] strides = [%c256, %c1] : !pto.tensor_view<?x?xf32>
      %1 = pto.make_tensor_view %arg2, shape = [%c256, %c32_1] strides = [%c32_1, %c1] : !pto.tensor_view<?x?xf32>
      %2 = pto.make_tensor_view %arg0, shape = [%c32, %c32_1] strides = [%c32_1, %c1] : !pto.tensor_view<?x?xf32>
      %3 = pto.make_tensor_view %arg3, shape = [%c1_0, %c32_1] strides = [%c32_1, %c1] : !pto.tensor_view<?x?xf32>
      %4 = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
      %5 = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
      %6 = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
      %7 = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>
      %8 = pto.alloc_tile : !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>
      %9 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
      %10 = pto.alloc_tile : !pto.tile_buf<loc=bias, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
      scf.for %arg5 = %c0 to %c8 step %c1 {
        %12 = arith.muli %arg5, %c32_2 : index
        %13 = pto.partition_view %0, offsets = [%c0, %12], sizes = [%c32_3, %c32_2] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
        %14 = pto.partition_view %1, offsets = [%12, %c0], sizes = [%c32_2, %c32_4] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
        %15 = pto.partition_view %3, offsets = [%c0, %c0], sizes = [%c1_0, %c32_4] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
        pto.tload ins(%13 : !pto.partition_tensor_view<32x32xf32>) outs(%4 : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
        pto.tload ins(%14 : !pto.partition_tensor_view<32x32xf32>) outs(%5 : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
        scf.if %arg4 {
          pto.tload ins(%15 : !pto.partition_tensor_view<1x32xf32>) outs(%6 : !pto.tile_buf<loc=mat, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
        } else {
        }
        pto.record_event[<TLOAD>, <TMOV_M2L>, <EVENT_ID0>]
        pto.wait_event[<TLOAD>, <TMOV_M2L>, <EVENT_ID0>]
        pto.tmov ins(%4 : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%7 : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>)
        pto.tmov ins(%5 : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%8 : !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
        scf.if %arg4 {
          pto.tmov ins(%6 : !pto.tile_buf<loc=mat, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%10 : !pto.tile_buf<loc=bias, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
        } else {
        }
        pto.record_event[<TMOV_M2L>, <TMATMUL>, <EVENT_ID0>]
        pto.wait_event[<TMOV_M2L>, <TMATMUL>, <EVENT_ID0>]
        %16 = arith.cmpi eq, %arg5, %c0 : index
        scf.if %16 {
          scf.if %arg4 {
            pto.tmatmul.bias ins(%7, %8, %10 : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>, !pto.tile_buf<loc=bias, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%9 : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
          } else {
            pto.tmatmul ins(%7, %8 : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%9 : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
          }
        } else {
          pto.tmatmul.acc ins(%9, %7, %8 : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>, !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%9 : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
        }
        pto.record_event[<TMATMUL>, <TLOAD>, <EVENT_ID0>]
        pto.wait_event[<TMATMUL>, <TLOAD>, <EVENT_ID0>]
      }
      pto.record_event[<TMATMUL>, <TSTORE_ACC>, <EVENT_ID0>]
      pto.wait_event[<TMATMUL>, <TSTORE_ACC>, <EVENT_ID0>]
      %11 = pto.partition_view %2, offsets = [%c0, %c0], sizes = [%c32_3, %c32_4] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
      pto.tstore ins(%9 : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) outs(%11 : !pto.partition_tensor_view<32x32xf32>)
    }
    return
  }
}
```

</details>

4. PTO IR without manual sync, gives to `ptoas --enable-insert-sync` as input:

<details>

```mlir
module attributes {"pto.device-spec" = "Ascend910B1"} {
  func.func @RunTMATMULSplitK(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>, %arg2: !pto.ptr<f32>, %arg3: !pto.ptr<f32>, %arg4: i1) {
    pto.section.cube {
      %c0 = arith.constant 0 : index
      %c1 = arith.constant 1 : index
      %c1_0 = arith.constant 1 : index
      %c32 = arith.constant 32 : index
      %c256 = arith.constant 256 : index
      %c32_1 = arith.constant 32 : index
      %c32_2 = arith.constant 32 : index
      %c8 = arith.constant 8 : index
      %c32_3 = arith.constant 32 : index
      %c32_4 = arith.constant 32 : index
      %0 = pto.make_tensor_view %arg1, shape = [%c32, %c256] strides = [%c256, %c1] : !pto.tensor_view<?x?xf32>
      %1 = pto.make_tensor_view %arg2, shape = [%c256, %c32_1] strides = [%c32_1, %c1] : !pto.tensor_view<?x?xf32>
      %2 = pto.make_tensor_view %arg0, shape = [%c32, %c32_1] strides = [%c32_1, %c1] : !pto.tensor_view<?x?xf32>
      %3 = pto.make_tensor_view %arg3, shape = [%c1_0, %c32_1] strides = [%c32_1, %c1] : !pto.tensor_view<?x?xf32>
      %4 = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
      %5 = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
      %6 = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
      %7 = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>
      %8 = pto.alloc_tile : !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>
      %9 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
      %10 = pto.alloc_tile : !pto.tile_buf<loc=bias, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
      scf.for %arg5 = %c0 to %c8 step %c1 {
        %12 = arith.muli %arg5, %c32_2 : index
        %13 = pto.partition_view %0, offsets = [%c0, %12], sizes = [%c32_3, %c32_2] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
        %14 = pto.partition_view %1, offsets = [%12, %c0], sizes = [%c32_2, %c32_4] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
        %15 = pto.partition_view %3, offsets = [%c0, %c0], sizes = [%c1_0, %c32_4] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
        pto.tload ins(%13 : !pto.partition_tensor_view<32x32xf32>) outs(%4 : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
        pto.tload ins(%14 : !pto.partition_tensor_view<32x32xf32>) outs(%5 : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
        scf.if %arg4 {
          pto.tload ins(%15 : !pto.partition_tensor_view<1x32xf32>) outs(%6 : !pto.tile_buf<loc=mat, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
        } else {
        }
        pto.tmov ins(%4 : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%7 : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>)
        pto.tmov ins(%5 : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%8 : !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
        scf.if %arg4 {
          pto.tmov ins(%6 : !pto.tile_buf<loc=mat, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%10 : !pto.tile_buf<loc=bias, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
        } else {
        }
        %16 = arith.cmpi eq, %arg5, %c0 : index
        scf.if %16 {
          scf.if %arg4 {
            pto.tmatmul.bias ins(%7, %8, %10 : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>, !pto.tile_buf<loc=bias, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%9 : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
          } else {
            pto.tmatmul ins(%7, %8 : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%9 : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
          }
        } else {
          pto.tmatmul.acc ins(%9, %7, %8 : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>, !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%9 : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
        }
      }
      %11 = pto.partition_view %2, offsets = [%c0, %c0], sizes = [%c32_3, %c32_4] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
      pto.tstore ins(%9 : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) outs(%11 : !pto.partition_tensor_view<32x32xf32>)
    }
    return
  }
}
```

</details>