### PR TITLE
Tidy up examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,10 @@
 # Validate all examples on NPU
 
+Set the target NPU device with `PTODSL_TEST_DEVICE_ID` (for example `3`).
+If this environment variable is not set, example/test scripts default to `0` (resolved as `npu:0`) and print a warning.
+
 ```bash
+export PTODSL_TEST_DEVICE_ID=0
 python ./validate_all_examples.py
 ```
 

--- a/examples/aot/add_dynamic_multicore/run_add.py
+++ b/examples/aot/add_dynamic_multicore/run_add.py
@@ -1,6 +1,7 @@
 import ctypes
 import torch
 import torch_npu
+from ptodsl.test_util import get_test_device
 
 
 def torch_to_ctypes(tensor):
@@ -30,7 +31,7 @@ def lib_to_func(lib):
 
 
 def test_add():
-    device = "npu:7"
+    device = get_test_device()
     torch.npu.set_device(device)
 
     lib_path = "./add_lib.so"

--- a/examples/aot/add_static_multicore/run_add.py
+++ b/examples/aot/add_static_multicore/run_add.py
@@ -1,6 +1,7 @@
 import ctypes
 import torch
 import torch_npu
+from ptodsl.test_util import get_test_device
 
 
 def torch_to_ctypes(tensor):
@@ -31,7 +32,7 @@ def lib_to_func(lib):
 
 
 def test_add():
-    device = "npu:0"
+    device = get_test_device()
     torch.npu.set_device(device)
 
     lib_path = "./add_lib.so"

--- a/examples/aot/matmul_dynbatch_multicore/run_matmul.py
+++ b/examples/aot/matmul_dynbatch_multicore/run_matmul.py
@@ -1,6 +1,7 @@
 import ctypes
 import torch
 import torch_npu
+from ptodsl.test_util import get_test_device
 
 
 def torch_to_ctypes(tensor):
@@ -30,7 +31,7 @@ def load_lib(lib_path):
 
 
 def test_matmul(verbose=False):
-    device = "npu:6"
+    device = get_test_device()
     torch.set_default_device(device)
     torch.npu.set_device(device)
     dtype = torch.float32

--- a/examples/aot/matmul_dynbatch_multicore_opt/run_matmul.py
+++ b/examples/aot/matmul_dynbatch_multicore_opt/run_matmul.py
@@ -2,6 +2,7 @@ import ctypes
 import time
 import torch
 import torch_npu
+from ptodsl.test_util import get_test_device
 try:
     import matplotlib.pyplot as plt
 except ImportError:
@@ -86,7 +87,7 @@ def load_lib(lib_path):
 
 
 def plot_benchmark():
-    device = "npu:7"
+    device = get_test_device()
     torch.set_default_device(device)
     torch.npu.set_device(device)
     dtype = torch.float32

--- a/examples/aot/matmul_static_singlecore/run_matmul.py
+++ b/examples/aot/matmul_static_singlecore/run_matmul.py
@@ -1,6 +1,7 @@
 import ctypes
 import torch
 import torch_npu
+from ptodsl.test_util import get_test_device
 
 
 def torch_to_ctypes(tensor):
@@ -31,7 +32,7 @@ def load_lib(lib_path):
 
 
 def test_matmul():
-    device = "npu:6"
+    device = get_test_device()
     torch.set_default_device(device)
     torch.npu.set_device(device)
     dtype = torch.float32

--- a/examples/aot/relu_dynamic_multicore/run_relu.py
+++ b/examples/aot/relu_dynamic_multicore/run_relu.py
@@ -13,6 +13,7 @@
 import ctypes
 import torch
 import torch_npu
+from ptodsl.test_util import get_test_device
 
 
 def torch_to_ctypes(tensor):
@@ -48,7 +49,7 @@ def load_lib(lib_path, block_dim, check_type=True):
 
 
 def test_relu(verbose=True):
-    device = "npu:1"
+    device = get_test_device()
     torch.set_default_device(device)
     torch.npu.set_device(device)
     dtype = torch.float32

--- a/examples/jit/add_dynamic_multicore/run_add.py
+++ b/examples/jit/add_dynamic_multicore/run_add.py
@@ -2,6 +2,7 @@ from ptodsl import jit
 import ptodsl.language as pto
 import torch
 import torch_npu
+from ptodsl.test_util import get_test_device
 
 const = pto.const
 
@@ -100,7 +101,7 @@ def vec_add_1d_dynamic(
 
 
 def test_add():
-    device = "npu:7"
+    device = get_test_device()
     torch.npu.set_device(device)
 
     # shape parameter hard-coded as kernel

--- a/examples/jit/add_static_multicore/run_add_1d.py
+++ b/examples/jit/add_static_multicore/run_add_1d.py
@@ -2,6 +2,7 @@ from ptodsl import jit
 import ptodsl.language as pto
 import torch
 import torch_npu
+from ptodsl.test_util import get_test_device
 
 const = pto.const
 
@@ -63,7 +64,7 @@ def vec_add_kernel(
 
 
 def test_add():
-    device = "npu:1"
+    device = get_test_device()
     torch.npu.set_device(device)
 
     shape = (1, 1024 * 20)  # tensor shape hard-coded as the kernel

--- a/examples/jit/add_static_multicore/run_add_2d.py
+++ b/examples/jit/add_static_multicore/run_add_2d.py
@@ -2,6 +2,7 @@ from ptodsl import jit
 import ptodsl.language as pto
 import torch
 import torch_npu
+from ptodsl.test_util import get_test_device
 
 const = pto.const
 
@@ -70,7 +71,7 @@ def vec_add_kernel(
 
 
 def test_add():
-    device = "npu:1"
+    device = get_test_device()
     torch.npu.set_device(device)
 
     shape = [1280, 32]  # tensor shape hard-coded as the kernel

--- a/examples/jit/matmul_dynamic_multicore/run_batch_matmul.py
+++ b/examples/jit/matmul_dynamic_multicore/run_batch_matmul.py
@@ -4,6 +4,7 @@ from ptodsl import jit
 import ptodsl.language as pto
 import torch
 import torch_npu
+from ptodsl.test_util import get_test_device
 
 const = pto.const
 
@@ -172,7 +173,7 @@ def build_kernel(
 
 
 def test_matmul():
-    device = "npu:6"
+    device = get_test_device()
     torch.set_default_device(device)
     torch.npu.set_device(device)
     dtype = torch.float32

--- a/examples/validate_all_examples.py
+++ b/examples/validate_all_examples.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
-"""Run all examples by executing commands from each example README."""
+"""Run all examples by executing commands from each example README.
+
+Environment:
+    PTODSL_TEST_DEVICE_ID: NPU device id used by example/test scripts (e.g. 0).
+    If unset, those scripts default to 0 (resolved to npu:0) and print a warning.
+"""
 
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import subprocess
 import sys
@@ -14,6 +20,7 @@ from pathlib import Path
 
 README_NAME = "README.md"
 SUPPORTED_LANGS = {"bash", "sh", "shell", ""}
+DEVICE_ENV_VAR = "PTODSL_TEST_DEVICE_ID"
 
 
 @dataclass
@@ -159,6 +166,13 @@ def main() -> int:
     args = parser.parse_args()
 
     examples_root = args.root.resolve()
+    device = os.getenv(DEVICE_ENV_VAR)
+    if device:
+        print(f"Using {DEVICE_ENV_VAR}={device}")
+    else:
+        print(
+            f"Warning: {DEVICE_ENV_VAR} is not set; scripts default to 0 (resolved to npu:0)."
+        )
     readmes = discover_example_readmes(examples_root)
     print_header(len(readmes))
 

--- a/ptodsl/test_util.py
+++ b/ptodsl/test_util.py
@@ -1,0 +1,19 @@
+import os
+
+
+DEVICE_ENV_VAR = "PTODSL_TEST_DEVICE_ID"
+DEFAULT_DEVICE_ID = "0"
+DEVICE_PREFIX = "npu:"
+
+
+def get_test_device() -> str:
+    device_id = os.getenv(DEVICE_ENV_VAR)
+    if not device_id:
+        print(
+            f"Warning: {DEVICE_ENV_VAR} is not set; defaulting to {DEFAULT_DEVICE_ID}."
+        )
+        device_id = DEFAULT_DEVICE_ID
+
+    if device_id.startswith(DEVICE_PREFIX):
+        return device_id
+    return f"{DEVICE_PREFIX}{device_id}"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,7 +1,9 @@
 Usage:
 
 ```bash
+export PTODSL_TEST_DEVICE_ID=0
 pytest -v .
 ```
 
 Note: put all on-device tests in [npu](./npu) subdirectory. The other directories only need host CPU.
+If `PTODSL_TEST_DEVICE_ID` is not set, NPU tests default to `0` (resolved as `npu:0`) and print a warning.

--- a/tests/npu/elementwise_dynamic_multicore/test_builder.py
+++ b/tests/npu/elementwise_dynamic_multicore/test_builder.py
@@ -5,11 +5,12 @@ import subprocess
 
 import pytest
 import torch
+from ptodsl.test_util import get_test_device
 
 torch.manual_seed(0)
 
 _DIR = os.path.dirname(os.path.abspath(__file__))
-_DEVICE = "npu:5"
+_DEVICE = get_test_device()
 
 BINARY_OPS = [
     ("add", lambda x, y: x + y),

--- a/tests/npu/gather_static_singlecore/test_gather.py
+++ b/tests/npu/gather_static_singlecore/test_gather.py
@@ -4,11 +4,12 @@ import subprocess
 
 import pytest
 import torch
+from ptodsl.test_util import get_test_device
 
 torch.manual_seed(0)
 
 _DIR = os.path.dirname(os.path.abspath(__file__))
-_DEVICE = "npu:6"
+_DEVICE = get_test_device()
 
 TORCH_DTYPES = {
     "float32": torch.float32,


### PR DESCRIPTION
- make matplotlib optional, solves https://github.com/huawei-csl/pto-dsl/pull/30#discussion_r2847618449
- unify the selection of NPU device id, otherwise `npu:0`, `npu:7` is randomly hard-coded everywhere. 

When a device ID is occupied or broken, `pytest` and `validate_all_examples.py` can now pick one & same ID using `export PTODSL_TEST_DEVICE_ID=2`, for example.

cc @fiskrt @MirkoDeVita98 