### PR TITLE
Gather dynamic multicore tests for float16

### DIFF
--- a/tests/npu/gather_dynamic_multicore/builder.py
+++ b/tests/npu/gather_dynamic_multicore/builder.py
@@ -1,0 +1,172 @@
+from ptodsl import to_ir_module
+import ptodsl.language as pto
+
+const = pto.const
+
+DTYPES = {
+    "float32": lambda: pto.float32,
+    "float16": lambda: pto.float16,
+    "int32": lambda: pto.int32,
+    "int16": lambda: pto.int16,
+}
+
+
+def meta_data(dtype=None, tile_length=32):
+    if dtype is None:
+        dtype = "float32"
+    if isinstance(dtype, str):
+        dtype = DTYPES[dtype]()
+
+    i32 = pto.int32
+    ptr_type = pto.PtrType(dtype)
+    ptr_i32 = pto.PtrType(i32)
+
+    tensor_type = pto.TensorType(rank=1, dtype=dtype)
+    tensor_i32 = pto.TensorType(rank=1, dtype=i32)
+
+    subtensor_type = pto.SubTensorType(shape=[1, tile_length], dtype=dtype)
+    subtensor_i32 = pto.SubTensorType(shape=[1, tile_length], dtype=i32)
+
+    tile_cfg = pto.TileBufConfig()
+    tile_type = pto.TileBufType(
+        shape=[1, tile_length],
+        valid_shape=[1, tile_length],
+        dtype=dtype,
+        memory_space="VEC",
+        config=tile_cfg,
+    )
+    tile_i32 = pto.TileBufType(
+        shape=[1, tile_length],
+        valid_shape=[1, tile_length],
+        dtype=i32,
+        memory_space="VEC",
+        config=tile_cfg,
+    )
+
+    return {
+        "ptr_type": ptr_type,
+        "ptr_i32": ptr_i32,
+        "index_dtype": i32,
+        "tensor_type": tensor_type,
+        "tensor_i32": tensor_i32,
+        "subtensor_type": subtensor_type,
+        "subtensor_i32": subtensor_i32,
+        "tile_type": tile_type,
+        "tile_i32": tile_i32,
+        "tile_length": tile_length,
+    }
+
+
+def build_gather_kernel(
+    fn_name="vec_gather_2d_dynamic_float32_P1111",
+    dtype="float32",
+    tile_length=32,
+    mask_pattern="P1111",
+):
+    """
+    1D dynamic multicore gather, same tiling logic as vec_add_1d_dynamic.
+
+    Per-tile semantics:
+      for each tile starting at base:
+        out[base + j] = src[base + indices[base + j]]
+
+    IMPORTANT:
+      - indices are *within-tile* indices, must be in [0, tile_length-1]
+      - argN is total elements
+      - works best when N is multiple of tile_length (no tail handling other than dropping extra tiles)
+    """
+    _meta_data = lambda: meta_data(dtype=dtype, tile_length=tile_length)
+
+    def _kernel(
+        arg0: "ptr_type",  # src (T*)
+        arg1: "ptr_i32",  # indices (i32*) values in [0..tile_length-1] per tile
+        arg2: "ptr_type",  # out (T*)
+        argB: "index_dtype",
+        argN: "index_dtype",
+    ) -> None:
+        c0 = const(0)
+        c1 = const(1)
+        c_tile = const(tile_length)
+
+        total_elements = pto.index_cast(argB * argN)  # B * N
+        cid = pto.get_block_idx()
+        sub_bid = pto.get_subblock_idx()
+        sub_bnum = pto.get_subblock_num()
+        vid = cid * sub_bnum + sub_bid
+        num_blocks = pto.get_block_num()
+
+        vid_idx = pto.index_cast(vid)
+        num_cores = pto.index_cast(num_blocks)
+
+        num_tiles_global = pto.ceil_div(total_elements, c_tile)
+        num_tiles_per_core = pto.ceil_div(num_tiles_global, num_cores)
+        tile_offset_this_core = vid_idx * num_tiles_per_core
+
+        with pto.vector_section():
+            tv0 = pto.as_tensor(
+                tensor_type, ptr=arg0, shape=[total_elements], strides=[c1]
+            )
+            tv1 = pto.as_tensor(
+                tensor_i32, ptr=arg1, shape=[total_elements], strides=[c1]
+            )
+            tv2 = pto.as_tensor(
+                tensor_type, ptr=arg2, shape=[total_elements], strides=[c1]
+            )
+
+            tb_src = pto.alloc_tile(tile_type)
+            tb_idx = pto.alloc_tile(tile_i32)
+            tb_tmp = pto.alloc_tile(tile_type)
+            tb_out = pto.alloc_tile(tile_type)
+
+            # Skip whole core if its starting tile is already out-of-bound.
+            with pto.if_context(tile_offset_this_core < num_tiles_global):
+                tiles_end_this_core = tile_offset_this_core + num_tiles_per_core
+                need_truncate = tiles_end_this_core > num_tiles_global
+                remaining_tiles = num_tiles_global - tile_offset_this_core
+                tiles_to_process = pto.select(
+                    need_truncate, remaining_tiles, num_tiles_per_core
+                )
+
+                elements_to_process = tiles_to_process * c_tile
+                with pto.if_context(elements_to_process > c0):
+                    for i in pto.for_range(c0, tiles_to_process, c1):
+                        tile_offset_global = i + tile_offset_this_core
+                        offset_global = tile_offset_global * c_tile
+
+                        sv0 = pto.slice_view(
+                            subtensor_type,
+                            source=tv0,
+                            offsets=[offset_global],
+                            sizes=[c_tile],
+                        )
+                        sv1 = pto.slice_view(
+                            subtensor_i32,
+                            source=tv1,
+                            offsets=[offset_global],
+                            sizes=[c_tile],
+                        )
+
+                        pto.load(sv0, tb_src)
+                        pto.load(sv1, tb_idx)
+
+                        # gather within tile by indices
+                        pto.gather(tb_src, tb_tmp, tb_idx)
+
+                        pto.gather(tb_tmp, tb_out, mask_pattern=mask_pattern)
+
+                        sv2 = pto.slice_view(
+                            subtensor_type,
+                            source=tv2,
+                            offsets=[offset_global],
+                            sizes=[c_tile],
+                        )
+
+                        pto.store(tb_out, sv2)
+
+    _kernel.__name__ = fn_name
+    return to_ir_module(meta_data=_meta_data)(_kernel)
+
+
+if __name__ == "__main__":
+    # example
+    print(build_gather_kernel(dtype="float32", tile_length=32, mask_pattern="P1111"))

--- a/tests/npu/gather_dynamic_multicore/caller.py
+++ b/tests/npu/gather_dynamic_multicore/caller.py
@@ -1,0 +1,38 @@
+"""Generate caller.cpp for the dynamic multicore gather kernel."""
+
+import sys
+
+_DTYPE_TO_CTYPE = {
+    "float32": "float",
+    "float16": "half",
+    "int16": "int16_t",
+    "int32": "int32_t",
+}
+
+
+def fn_name(dtype, mask_pattern="P1111"):
+    return f"vec_gather_2d_dynamic_{dtype}_{mask_pattern}"
+
+
+def generate_caller(dtype, mask_pattern="P1111"):
+    src_ctype = _DTYPE_TO_CTYPE[dtype]
+    fn = fn_name(dtype, mask_pattern)
+    return f"""\
+#include "{fn}.cpp"
+
+extern "C" void call_{fn}(
+    void *stream, uint8_t *src, uint8_t *indices, uint8_t *out, int32_t B, int32_t N)
+{{
+    {fn}<<<20, nullptr, stream>>>(
+        ({src_ctype} *)src, (int32_t *)indices, ({src_ctype} *)out, B, N);
+}}
+"""
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python caller.py <dtype> [mask_pattern]", file=sys.stderr)
+        sys.exit(1)
+    dtype = sys.argv[1]
+    mask_pattern = sys.argv[2] if len(sys.argv) > 2 else "P1111"
+    print(generate_caller(dtype, mask_pattern))

--- a/tests/npu/gather_dynamic_multicore/compile.sh
+++ b/tests/npu/gather_dynamic_multicore/compile.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+DTYPE=${1:?Usage: compile.sh <dtype> [mask_pattern]}
+MASK=${2:-P1111}
+
+FN_NAME="vec_gather_2d_dynamic_${DTYPE}_${MASK}"
+
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+
+# Generate IR and compile the gather kernel
+python "$SCRIPT_DIR/gen_ir.py" "$DTYPE" "$MASK" > "$TMP/${FN_NAME}.pto"
+ptoas --enable-insert-sync "$TMP/${FN_NAME}.pto" -o "$TMP/${FN_NAME}.cpp"
+
+# Generate caller.cpp
+python "$SCRIPT_DIR/caller.py" "$DTYPE" "$MASK" > "$TMP/caller.cpp"
+
+PTO_LIB_PATH=/sources/pto-isa
+bisheng \
+    -I${PTO_LIB_PATH}/include \
+    -fPIC -shared -D_FORTIFY_SOURCE=2 -O2 -std=c++17 \
+    -Wno-macro-redefined -Wno-ignored-attributes -fstack-protector-strong \
+    -xcce -Xhost-start -Xhost-end \
+    -mllvm -cce-aicore-stack-size=0x8000 \
+    -mllvm -cce-aicore-function-stack-size=0x8000 \
+    -mllvm -cce-aicore-record-overflow=true \
+    -mllvm -cce-aicore-addr-transform \
+    -mllvm -cce-aicore-dcci-insert-for-scalar=false \
+    --npu-arch=dav-2201 -DMEMORY_BASE \
+    -std=gnu++17 \
+    "$TMP/caller.cpp" \
+    -o "$SCRIPT_DIR/${FN_NAME}_lib.so"
+
+echo "Built ${FN_NAME}_lib.so successfully."

--- a/tests/npu/gather_dynamic_multicore/gen_ir.py
+++ b/tests/npu/gather_dynamic_multicore/gen_ir.py
@@ -1,0 +1,27 @@
+"""Print MLIR IR for the dynamic multicore gather kernel.
+
+Usage: python gen_ir.py <dtype> [mask_pattern]
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from builder import build_gather_kernel
+
+
+def fn_name(dtype, mask_pattern="P1111"):
+    return f"vec_gather_2d_dynamic_{dtype}_{mask_pattern}"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python gen_ir.py <dtype> [mask_pattern]", file=sys.stderr)
+        sys.exit(1)
+    dtype = sys.argv[1]
+    mask_pattern = sys.argv[2] if len(sys.argv) > 2 else "P1111"
+    module = build_gather_kernel(
+        fn_name=fn_name(dtype, mask_pattern), dtype=dtype, mask_pattern=mask_pattern
+    )
+    print(module)

--- a/tests/npu/gather_dynamic_multicore/test_gather_dynamic.py
+++ b/tests/npu/gather_dynamic_multicore/test_gather_dynamic.py
@@ -1,0 +1,202 @@
+import os
+import ctypes
+import subprocess
+
+import pytest
+import torch
+from ptodsl.test_util import get_test_device
+
+torch.manual_seed(0)
+
+_DIR = os.path.dirname(os.path.abspath(__file__))
+_DEVICE = get_test_device()
+
+TORCH_DTYPES = {
+    "float32": torch.float32,
+    "float16": torch.float16,
+    "int16": torch.int16,
+    "int32": torch.int32,
+}
+
+# One kernel compiled per (dtype, mask_pattern).
+CASES = [
+    ("float16", "P0101"),
+    ("float16", "P1111"),
+    ("float16", "P0001"),
+    ("float16", "P1010")
+]
+
+# Runtime shapes (B, N). N must be a multiple of 32.
+SHAPES = [(1, 64), (8, 64), (4, 128), (2, 256)]
+
+NUM_BLOCKS = 20
+TILE = 32
+
+
+def _case_id(dtype, mask_pattern):
+    return f"vec_gather_2d_dynamic_{dtype}_{mask_pattern}"
+
+
+_PARAMS = [
+    pytest.param((dtype, mask_pattern), id=f"{dtype}-{mask_pattern}")
+    for dtype, mask_pattern in CASES
+]
+
+
+def _lib_path(dtype, mask_pattern):
+    return os.path.join(_DIR, f"{_case_id(dtype, mask_pattern)}_lib.so")
+
+
+def _ctypes_ptr(tensor):
+    return ctypes.c_void_p(tensor.data_ptr())
+
+
+@pytest.fixture(scope="session", params=_PARAMS)
+def compiled_lib(request):
+    dtype, mask_pattern = request.param
+    subprocess.check_call(
+        ["bash", os.path.join(_DIR, "compile.sh"), dtype, mask_pattern],
+        cwd=_DIR,
+    )
+    yield {"dtype": dtype, "mask_pattern": mask_pattern}
+    os.remove(_lib_path(dtype, mask_pattern))
+
+
+def _make_src(shape, device, torch_dtype):
+    if torch_dtype.is_floating_point:
+        return torch.rand(shape, device=device, dtype=torch_dtype) + 0.1
+    return torch.randint(0, 1000, shape, device=device, dtype=torch_dtype)
+
+
+def init_indices_per_block(B, N, num_blocks, device):
+    """
+    Create per-tile within-tile element indices for each block's assigned tile range.
+
+    Indices are element indices within each tile: values in [0, TILE-1].
+    Per-tile semantics: out[base + j] = src[base + indices[base + j]]
+    """
+    assert N % TILE == 0
+    total = B * N
+    num_tiles = total // TILE
+    tiles_per_block = (num_tiles + num_blocks - 1) // num_blocks
+
+    flat = torch.empty((total,), device=device, dtype=torch.int32)
+
+    for bid in range(num_blocks):
+        start_tile = bid * tiles_per_block
+        end_tile = min(num_tiles, start_tile + tiles_per_block)
+        if start_tile >= end_tile:
+            continue
+
+        start = start_tile * TILE
+        end = end_tile * TILE
+
+        flat[start:end] = torch.randint(
+            0, TILE, (end - start,), device=device, dtype=torch.int32
+        )
+
+    return flat.view(B, N).to(torch.int32)
+
+
+def _gather_ref_blocked(src, indices, mask_pattern, num_blocks=NUM_BLOCKS):
+    """
+    Reference matching the kernel partitioning by blocks (NUM_BLOCKS).
+    Indices are within-tile element indices in [0, TILE-1].
+
+    Per-tile semantics: out[base + j] = src[base + indices[base + j]]
+    """
+    B, N = src.shape
+    assert N % TILE == 0
+
+    total = B * N
+    num_tiles = total // TILE
+    tiles_per_block = (num_tiles + num_blocks - 1) // num_blocks
+
+    flat_src = src.reshape(-1)
+    flat_idx = indices.reshape(-1).to(torch.int64)
+
+    flat_out = torch.empty_like(flat_src)
+
+    for bid in range(num_blocks):
+        start_tile = bid * tiles_per_block
+        end_tile = min(num_tiles, start_tile + tiles_per_block)
+        if start_tile >= end_tile:
+            continue
+
+        tile_ids = torch.arange(
+            start_tile, end_tile, device=src.device, dtype=torch.int64
+        )
+        base = (tile_ids * TILE).repeat_interleave(TILE)
+        lane = torch.arange(TILE, device=src.device, dtype=torch.int64).repeat(
+            end_tile - start_tile
+        )
+
+        pos = base + lane
+        src_pos = base + flat_idx[pos]
+        gathered = flat_src[src_pos]
+
+        if mask_pattern == "P1111":
+            flat_out[pos] = gathered
+        elif mask_pattern == "P0101":
+            flat_out[pos] = 0
+            keep = lane % 2 == 0
+            packed_lane = lane // 2
+            packed_pos = base + packed_lane
+            flat_out[packed_pos[keep]] = gathered[keep]
+        elif mask_pattern == "P1010":
+            flat_out[pos] = 0
+            keep = lane % 2 == 1
+            packed_lane = lane // 2
+            packed_pos = base + packed_lane
+            flat_out[packed_pos[keep]] = gathered[keep]
+        elif mask_pattern == "P0001":
+            flat_out[pos] = 0
+            keep = lane % 4 == 0
+            packed_lane = lane // 4
+            packed_pos = base + packed_lane
+            flat_out[packed_pos[keep]] = gathered[keep]
+        else:
+            raise ValueError(mask_pattern)
+
+    return flat_out.view(B, N)
+
+
+def test_build_gather(compiled_lib):
+    dtype, mask_pattern = compiled_lib["dtype"], compiled_lib["mask_pattern"]
+    assert os.path.exists(_lib_path(dtype, mask_pattern))
+
+
+@pytest.mark.require_npu
+def test_gather_dynamic(compiled_lib):
+    import torch_npu
+
+    torch.npu.set_device(_DEVICE)
+    dtype = compiled_lib["dtype"]
+    mask_pattern = compiled_lib["mask_pattern"]
+    torch_dtype = TORCH_DTYPES[dtype]
+
+    lib = ctypes.CDLL(_lib_path(dtype, mask_pattern))
+    fn = getattr(lib, f"call_{_case_id(dtype, mask_pattern)}")
+    stream_ptr = torch.npu.current_stream()._as_parameter_
+
+    for B, N in SHAPES:
+        src = _make_src((B, N), _DEVICE, torch_dtype)
+
+        # indices are within-tile element indices in [0, TILE-1]
+        indices = init_indices_per_block(B, N, NUM_BLOCKS, _DEVICE)
+
+        out = torch.empty((B, N), device=_DEVICE, dtype=torch_dtype)
+
+        torch.npu.synchronize()
+        fn(stream_ptr, _ctypes_ptr(src), _ctypes_ptr(indices), _ctypes_ptr(out), B, N)
+        torch.npu.synchronize()
+
+        ref = _gather_ref_blocked(src, indices, mask_pattern, num_blocks=NUM_BLOCKS)
+
+        torch.testing.assert_close(
+            out, ref, msg=f"shape=({B},{N}), mask={mask_pattern}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
This PR enables tests for gather dynamic multicore. The kernel is only compiled when mask pattern and/or the dtype is changed. Currently the tests pass only for float16.