### PR TITLE
Parameterize dynamic shape gather test, and mark `xfail`, for better error reporting

### DIFF
--- a/tests/npu/gather_dynamic_multicore/test_gather_dynamic.py
+++ b/tests/npu/gather_dynamic_multicore/test_gather_dynamic.py
@@ -168,6 +168,7 @@ def test_build_gather(compiled_lib):
 
 
 @pytest.mark.require_npu
+@pytest.mark.xfail(reason="Known unsolved issues of indeterministic output values", strict=False)
 @pytest.mark.parametrize("B, N", _SHAPE_PARAMS)
 def test_gather_dynamic(compiled_lib, B, N):
     import torch_npu


### PR DESCRIPTION
`pytest -v tests/npu/gather_dynamic_multicore/test_gather_dynamic.py` has indeterministic error.

Sometimes all success:

```
================================================================= test session starts ==================================================================
platform linux -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/python3.11.14/bin/python3.11
cachedir: .pytest_cache
rootdir: /mounted_home/work_code/pto-dsl
plugins: anyio-4.12.1
collected 20 items                                                                                                                                     

tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_build_gather[float16-P0101] PASSED                                               [  5%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0101-B1-N64] PASSED                                      [ 10%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0101-B8-N64] PASSED                                      [ 15%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0101-B4-N128] PASSED                                     [ 20%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0101-B2-N256] PASSED                                     [ 25%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_build_gather[float16-P1111] PASSED                                               [ 30%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P1111-B1-N64] PASSED                                      [ 35%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P1111-B8-N64] PASSED                                      [ 40%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P1111-B4-N128] PASSED                                     [ 45%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P1111-B2-N256] PASSED                                     [ 50%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_build_gather[float16-P0001] PASSED                                               [ 55%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0001-B1-N64] PASSED                                      [ 60%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0001-B8-N64] PASSED                                      [ 65%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0001-B4-N128] PASSED                                     [ 70%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0001-B2-N256] PASSED                                     [ 75%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_build_gather[float16-P1010] PASSED                                               [ 80%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P1010-B1-N64] PASSED                                      [ 85%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P1010-B8-N64] PASSED                                      [ 90%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P1010-B4-N128] PASSED                                     [ 95%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P1010-B2-N256] PASSED                                     [100%]

================================================================= 20 passed in 26.40s ==================================================================
```

Sometimes fail on all shapes of `P0101` and `P0001`

```
=============================================================== short test summary info ================================================================
FAILED tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0101-B1-N64] - AssertionError: shape=(1,64), mask=P0101
FAILED tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0101-B8-N64] - AssertionError: shape=(8,64), mask=P0101
FAILED tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0101-B4-N128] - AssertionError: shape=(4,128), mask=P0101
FAILED tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0101-B2-N256] - AssertionError: shape=(2,256), mask=P0101
FAILED tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0001-B1-N64] - AssertionError: shape=(1,64), mask=P0001
FAILED tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0001-B8-N64] - AssertionError: shape=(8,64), mask=P0001
FAILED tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0001-B4-N128] - AssertionError: shape=(4,128), mask=P0001
FAILED tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0001-B2-N256] - AssertionError: shape=(2,256), mask=P0001
============================================================ 8 failed, 12 passed in 27.00s =============================================================
```

Sometimes only fail on `P0101`

```
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py:197: AssertionError
=============================================================== short test summary info ================================================================
FAILED tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0101-B1-N64] - AssertionError: shape=(1,64), mask=P0101
FAILED tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0101-B8-N64] - AssertionError: shape=(8,64), mask=P0101
FAILED tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0101-B4-N128] - AssertionError: shape=(4,128), mask=P0101
FAILED tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0101-B2-N256] - AssertionError: shape=(2,256), mask=P0101
============================================================ 4 failed, 16 passed in 27.15s =============================================================
```


## Changed to `xfail` until fully resolved

cc @MirkoDeVita98 

```
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_build_gather[float16-P0101] PASSED                                               [  5%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0101-B1-N64] XFAIL (Known unsolved issues of indeter...) [ 10%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0101-B8-N64] XFAIL (Known unsolved issues of indeter...) [ 15%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0101-B4-N128] XFAIL (Known unsolved issues of indete...) [ 20%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0101-B2-N256] XFAIL (Known unsolved issues of indete...) [ 25%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_build_gather[float16-P1111] PASSED                                               [ 30%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P1111-B1-N64] XFAIL (Known unsolved issues of indeter...) [ 35%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P1111-B8-N64] XFAIL (Known unsolved issues of indeter...) [ 40%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P1111-B4-N128] XFAIL (Known unsolved issues of indete...) [ 45%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P1111-B2-N256] XFAIL (Known unsolved issues of indete...) [ 50%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_build_gather[float16-P0001] PASSED                                               [ 55%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0001-B1-N64] XFAIL (Known unsolved issues of indeter...) [ 60%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0001-B8-N64] XPASS (Known unsolved issues of indeter...) [ 65%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0001-B4-N128] XPASS (Known unsolved issues of indete...) [ 70%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P0001-B2-N256] XPASS (Known unsolved issues of indete...) [ 75%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_build_gather[float16-P1010] PASSED                                               [ 80%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P1010-B1-N64] XPASS (Known unsolved issues of indeter...) [ 85%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P1010-B8-N64] XPASS (Known unsolved issues of indeter...) [ 90%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P1010-B4-N128] XPASS (Known unsolved issues of indete...) [ 95%]
tests/npu/gather_dynamic_multicore/test_gather_dynamic.py::test_gather_dynamic[float16-P1010-B2-N256] XPASS (Known unsolved issues of indete...) [100%]

======================================================= 4 passed, 9 xfailed, 7 xpassed in 28.15s =======================================================
```