### PR TITLE
Free up resources in examples and other fixes

### DIFF
--- a/examples/aot/matmul_optimization_guide/bench_matmul.py
+++ b/examples/aot/matmul_optimization_guide/bench_matmul.py
@@ -342,6 +342,8 @@ def main():
                 args.warmup,
                 args.repeat,
             )
+            del a_list, b_list
+            torch.npu.empty_cache()
 
             flops = 2.0 * m * n * k
             double_auto_swizzle_tflops = flops / double_auto_swizzle_us / 1e6

--- a/examples/aot/matmul_optimization_guide/experimental/bench_matmul.py
+++ b/examples/aot/matmul_optimization_guide/experimental/bench_matmul.py
@@ -429,6 +429,9 @@ def main():
                     }
                 )
 
+            del a_list, b_list, c, c_ref
+            torch.npu.empty_cache()
+
             if no_swizzle_time_us is None or no_swizzle_tflops is None:
                 raise RuntimeError(
                     "No no-swizzle baseline result found "

--- a/examples/aot/matmul_optimization_guide/experimental/run_matmul.py
+++ b/examples/aot/matmul_optimization_guide/experimental/run_matmul.py
@@ -106,7 +106,7 @@ def run_case(matmul_abt, a, b, c_ref, *, block_dim, swizzle_direction, swizzle_c
         swizzle_count=swizzle_count,
     )
     torch.npu.synchronize()
-    return CaseResult(
+    result = CaseResult(
         m=int(a.shape[0]),
         n=int(b.shape[0]),
         k=int(a.shape[1]),
@@ -116,6 +116,9 @@ def run_case(matmul_abt, a, b, c_ref, *, block_dim, swizzle_direction, swizzle_c
         max_absdiff=float((c - c_ref).abs().max().item()),
         mean_absdiff=float((c - c_ref).abs().mean().item()),
     )
+    del c
+    torch.npu.empty_cache()
+    return result
 
 
 def test_matmul():
@@ -168,6 +171,9 @@ def test_matmul():
                             )
                         ):
                             global_worst = result
+
+            del a, b, c_ref
+            torch.npu.empty_cache()
 
             print(
                 f"(m, n, k)=({m}, {n}, {k}) "

--- a/examples/aot/matmul_optimization_guide/run_matmul.py
+++ b/examples/aot/matmul_optimization_guide/run_matmul.py
@@ -91,7 +91,7 @@ def load_lib(lib_path):
 def run_case(matmul_abt, a, b, c_ref, *, block_dim):
     c = matmul_abt(a, b, block_dim=block_dim)
     torch.npu.synchronize()
-    return CaseResult(
+    result = CaseResult(
         m=int(a.shape[0]),
         n=int(b.shape[0]),
         k=int(a.shape[1]),
@@ -99,6 +99,9 @@ def run_case(matmul_abt, a, b, c_ref, *, block_dim):
         max_absdiff=float((c - c_ref).abs().max().item()),
         mean_absdiff=float((c - c_ref).abs().mean().item()),
     )
+    del c
+    torch.npu.empty_cache()
+    return result
 
 
 def test_matmul():
@@ -174,6 +177,9 @@ def test_matmul():
                         )
                     ):
                         global_worst = result
+
+                del a, b, c_ref
+                torch.npu.empty_cache()
 
                 print(
                     f"(m, n, k)=({m}, {n}, {k}) "

--- a/examples/aot/print_tile/compile.sh
+++ b/examples/aot/print_tile/compile.sh
@@ -2,6 +2,8 @@
 #!/usr/bin/env bash
 set -e
 
+ARCH=$(uname -m)
+
 PTO_DIR="$ASCEND_HOME_PATH/include/pto"
 PTO_BACKUP="$ASCEND_HOME_PATH/include/pto_hidden"
 PTO_LIB_PATH="/sources/pto-isa"
@@ -30,7 +32,7 @@ bisheng \
     -xcce -Xhost-start -Xhost-end \
     --npu-arch=dav-2201 -DMEMORY_BASE \
     -D_DEBUG --cce-enable-print \
-    -I${ASCEND_HOME_PATH}/aarch64-linux/pkg_inc/runtime/runtime \
+    -I${ASCEND_HOME_PATH}/${ARCH}-linux/pkg_inc/runtime/runtime \
     -I${PTO_LIB_PATH}/include \
     -std=gnu++17 \
     ./caller.cpp \


### PR DESCRIPTION
I was working on B4 device and matmul opt examples would fail due to out of memory issues. The matrices for individual tests are not large, but they are not freed between successive benchmark runs, so it exhausts the memory of the smaller B4. Not a big deal, but is nice to see the tests pass. While I was at it, I also changed the `print_tile` example to not have hardcoded `aarch64` headers so it can work on x86_64 as well (but it still requires additional setup and doesn't work with provided docker)