### PR TITLE
Quant dynamic multicore tests for sym and asym variants and changed hardcoded PTO_LIB_PATH in etsts and examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,8 +3,11 @@
 Set the target NPU device with `PTODSL_TEST_DEVICE_ID` (for example `3`).
 If this environment variable is not set, example/test scripts default to `0` (resolved as `npu:0`) and print a warning.
 
+JIT (AOT) examples also require `PTO_LIB_PATH` to point to the `pto-isa` installation so the compiler can find its headers.
+
 ```bash
 export PTODSL_TEST_DEVICE_ID=0
+export PTO_LIB_PATH=/sources/pto-isa
 python ./validate_all_examples.py
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,10 +4,11 @@ Set the target NPU device with `PTODSL_TEST_DEVICE_ID` (for example `3`).
 If this environment variable is not set, example/test scripts default to `0` (resolved as `npu:0`) and print a warning.
 
 JIT (AOT) examples also require `PTO_LIB_PATH` to point to the `pto-isa` installation so the compiler can find its headers.
+By default it resolves to `/sources/pto-isa`, but you can export it to a different path before running.
 
 ```bash
 export PTODSL_TEST_DEVICE_ID=0
-export PTO_LIB_PATH=/sources/pto-isa
+export PTO_LIB_PATH=/sources/pto-isa  # optional: override the default path
 python ./validate_all_examples.py
 ```
 

--- a/examples/aot/activations/geglu_dynamic_multicore/compile.sh
+++ b/examples/aot/activations/geglu_dynamic_multicore/compile.sh
@@ -6,7 +6,7 @@ python ./geglu_builder.py > ./geglu.pto
 ptoas --enable-insert-sync ./geglu.pto -o ./geglu.cpp
 
 # CANN 8.5 headers don't have CompactMode, need latest pto-isa source
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 bisheng \
     -I${PTO_LIB_PATH}/include \
     -fPIC -shared -D_FORTIFY_SOURCE=2 -O2 -std=c++17 \

--- a/examples/aot/activations/relu_dynamic_multicore/compile.sh
+++ b/examples/aot/activations/relu_dynamic_multicore/compile.sh
@@ -3,7 +3,7 @@ python relu_builder.py > ./relu.pto
 ptoas --enable-insert-sync ./relu.pto > generated_relu.cpp
 
 # CANN 8.5 heaer has no TRELU support, need latest source
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 bisheng -fPIC -shared -xcce \
     --npu-arch=dav-2201 -DMEMORY_BASE \
     -O2 -std=c++17 \

--- a/examples/aot/batch_matmul/matmul_dynbatch_multicore/compile.sh
+++ b/examples/aot/batch_matmul/matmul_dynbatch_multicore/compile.sh
@@ -4,7 +4,7 @@ python ./matmul_builder.py > matmul.pto
 ptoas matmul.pto -o matmul.cpp
 
 # CANN 8.5 headers don't have CompactMode, need latest pto-isa source
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 bisheng -fPIC -shared -xcce -O2 -std=c++17 \
     --npu-arch=dav-2201 -DMEMORY_BASE \
     -I${PTO_LIB_PATH}/include \

--- a/examples/aot/batch_matmul/matmul_dynbatch_multicore_2buf/compile.sh
+++ b/examples/aot/batch_matmul/matmul_dynbatch_multicore_2buf/compile.sh
@@ -3,7 +3,7 @@ rm mul.cpp matmul_kernel.so
 python ./matmul_dsl.py | ptoas > mul.cpp
 
 # CANN 8.5 headers don't have CompactMode, need latest pto-isa source
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 bisheng -fPIC -shared -xcce -O2 -std=c++17 \
     --npu-arch=dav-2201 -DMEMORY_BASE \
     -I${PTO_LIB_PATH}/include \

--- a/examples/aot/batch_matmul/matmul_dynbatch_multicore_opt/compile.sh
+++ b/examples/aot/batch_matmul/matmul_dynbatch_multicore_opt/compile.sh
@@ -4,7 +4,7 @@ python ./matmul_builder.py > matmul.pto
 ptoas matmul.pto -o matmul.cpp
 
 # CANN 8.5 headers don't have CompactMode, need latest pto-isa source
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 bisheng -fPIC -shared -xcce -O2 -std=c++17 \
     --npu-arch=dav-2201 -DMEMORY_BASE \
     -I${PTO_LIB_PATH}/include \

--- a/examples/aot/elementwise/add_dynamic_multicore/compile.sh
+++ b/examples/aot/elementwise/add_dynamic_multicore/compile.sh
@@ -4,7 +4,7 @@ python ./add_builder.py > ./add.pto
 ptoas --enable-insert-sync ./add.pto -o ./add.cpp
 
 # CANN 8.5 headers don't have CompactMode, need latest pto-isa source
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 bisheng \
     -I${PTO_LIB_PATH}/include \
     -fPIC -shared -D_FORTIFY_SOURCE=2 -O2 -std=c++17 \

--- a/examples/aot/elementwise/add_dynamic_multicore/compile_double.sh
+++ b/examples/aot/elementwise/add_dynamic_multicore/compile_double.sh
@@ -4,7 +4,7 @@ python ./add_double_builder.py > ./add_double.pto
 ptoas --enable-insert-sync ./add_double.pto -o ./add_double.cpp
 
 # CANN 8.5 headers don't have CompactMode, need latest pto-isa source
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 bisheng \
     -I${PTO_LIB_PATH}/include \
     -fPIC -shared -D_FORTIFY_SOURCE=2 -O2 -std=c++17 \

--- a/examples/aot/fast_hadamard/compile.sh
+++ b/examples/aot/fast_hadamard/compile.sh
@@ -17,7 +17,7 @@ python ./hadamard_builder.py --manual-sync > ./hadamard_manual_sync.pto
 ptoas ./hadamard_manual_sync.pto -o ./hadamard_manual_sync.cpp
 
 # CANN 8.5 headers don't have CompactMode, need latest pto-isa source
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 bisheng \
     -I${PTO_LIB_PATH}/include \
     -fPIC -shared -D_FORTIFY_SOURCE=2 -O2 -std=c++17 \

--- a/examples/aot/fast_inverse/basic_dense/compile.sh
+++ b/examples/aot/fast_inverse/basic_dense/compile.sh
@@ -14,7 +14,7 @@ rm -f "${ARTIFACT_DIR}/inverse.pto" "${ARTIFACT_DIR}/inverse.cpp" "inverse_lib.s
 python ./inverse_builder.py --matrix-size "${MATRIX_SIZE}" > "${ARTIFACT_DIR}/inverse.pto"
 ptoas --enable-insert-sync "${ARTIFACT_DIR}/inverse.pto" -o "${ARTIFACT_DIR}/inverse.cpp"
 
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 # PTO_LIB_PATH=$ASCEND_TOOLKIT_HOME
 
 bisheng \

--- a/examples/aot/fast_inverse/block_inversion/compile.sh
+++ b/examples/aot/fast_inverse/block_inversion/compile.sh
@@ -13,7 +13,7 @@ python ./inverse_builder.py \
 
 ptoas --enable-insert-sync "${ARTIFACT_DIR}/inverse.pto" -o "${ARTIFACT_DIR}/inverse.cpp"
 
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 
 bisheng \
     -I${PTO_LIB_PATH}/include \

--- a/examples/aot/matmul_optimization_guide/compile.sh
+++ b/examples/aot/matmul_optimization_guide/compile.sh
@@ -7,7 +7,7 @@ mkdir -p "${ARTIFACT_DIR}"
 rm -f "${ARTIFACT_DIR}"/*.pto "${ARTIFACT_DIR}"/*.cpp "${ARTIFACT_DIR}"/*.so
 
 # CANN 8.5 headers don't have CompactMode, need latest pto-isa source
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 
 # Step1 baseline: functionally correct dynamic-shape matmul without optimizations.
 python ./step1_baseline.py > "${ARTIFACT_DIR}/step1_baseline.pto"

--- a/examples/aot/matmul_optimization_guide/experimental/compile.sh
+++ b/examples/aot/matmul_optimization_guide/experimental/compile.sh
@@ -7,7 +7,7 @@ python ./matmul_builder.py > matmul.pto
 ptoas matmul.pto -o matmul.cpp
 
 # CANN 8.5 headers don't have CompactMode, need latest pto-isa source
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 bisheng -fPIC -shared -xcce -O2 -std=c++17 \
     --npu-arch=dav-2201 -DMEMORY_BASE \
     -I"${PTO_LIB_PATH}/include" \

--- a/examples/aot/print_tile/compile.sh
+++ b/examples/aot/print_tile/compile.sh
@@ -6,7 +6,7 @@ ARCH=$(uname -m)
 
 PTO_DIR="$ASCEND_HOME_PATH/include/pto"
 PTO_BACKUP="$ASCEND_HOME_PATH/include/pto_hidden"
-PTO_LIB_PATH="/sources/pto-isa"
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 [ -d "$PTO_LIB_PATH" ] || exit 0
 
 

--- a/examples/aot/simple_static/add_static_multicore/compile.sh
+++ b/examples/aot/simple_static/add_static_multicore/compile.sh
@@ -4,7 +4,7 @@ python ./add_builder.py > ./add.pto
 ptoas --enable-insert-sync ./add.pto -o ./add.cpp
 
 # CANN 8.5 headers don't have CompactMode, need latest pto-isa source
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 bisheng \
     -I${PTO_LIB_PATH}/include \
     -fPIC -shared -D_FORTIFY_SOURCE=2 -O2 -std=c++17 \

--- a/examples/aot/simple_static/matmul_static_singlecore/compile.sh
+++ b/examples/aot/simple_static/matmul_static_singlecore/compile.sh
@@ -4,7 +4,7 @@ python ./matmul_builder.py > matmul.pto
 ptoas --enable-insert-sync matmul.pto -o matmul.cpp
 
 # CANN 8.5 headers don't have CompactMode, need latest pto-isa source
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 bisheng -fPIC -shared -xcce -O2 -std=c++17 \
     --npu-arch=dav-2201 -DMEMORY_BASE \
     -I${PTO_LIB_PATH}/include \

--- a/examples/aot/topk/compile.sh
+++ b/examples/aot/topk/compile.sh
@@ -26,7 +26,7 @@ ptoas --enable-insert-sync "$TMP/${FN}.pto" -o "$TMP/${FN}.cpp"
 python "$SCRIPT_DIR/caller.py" "$FN" > "$TMP/caller.cpp"
 
 # CANN 8.5 headers don't have CompactMode, need latest pto-isa source
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 bisheng \
     -I${PTO_LIB_PATH}/include \
     -fPIC -shared -D_FORTIFY_SOURCE=2 -O2 -std=c++17 \

--- a/ptodsl/api/pto.py
+++ b/ptodsl/api/pto.py
@@ -45,6 +45,8 @@ __all__ = [
     "bool",
     "float16",
     "float32",
+    "int8",
+    "uint8",
     "int16",
     "int32",
     "ffts_type",

--- a/ptodsl/api/scalar.py
+++ b/ptodsl/api/scalar.py
@@ -99,6 +99,8 @@ def __getattr__(name):
         return IntegerType.get_signless(8)
     if name == "uint32":
         return IntegerType.get_unsigned(32)
+    if name == "int8":
+        return IntegerType.get_signed(8)
     if name == "uint8":
         return IntegerType.get_unsigned(8)
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/ptodsl/api/tile.py
+++ b/ptodsl/api/tile.py
@@ -246,6 +246,24 @@ def cvt(src, dst, *, rmode=None):
     _pto.TCvtOp(src=src, dst=dst, rmode=rmode_attr)
 
 
+_QUANT_TYPE = {
+    "int8_sym": _pto.QuantType.INT8_SYM,
+    "int8_asym": _pto.QuantType.INT8_ASYM,
+}
+
+
+def quant(src, fp, dst, quant_type, *, offset=None):
+    """Quantize fp32 src tile to int8/uint8 dst tile.
+
+    quant_type: "int8_sym"  → signed int8,   dst = clip(round(src * fp), -128, 127)
+                "int8_asym" → unsigned uint8, dst = clip(round(src * fp + offset), 0, 255)
+    fp:     inverse-scale tile, same shape as src.
+    offset: zero-point tile, same shape as src (int8_asym only).
+    """
+    qtype_attr = _pto.QuantTypeAttr.get(_QUANT_TYPE[quant_type])
+    _pto.TQuantOp(src=src, fp=fp, dst=dst, quant_type=qtype_attr, offset=offset)
+
+
 def subset(source, offsets, sizes):
     offset_vals = [_unwrap(v) for v in offsets]
     return _pto.subset(source, offset_vals, sizes)
@@ -305,5 +323,6 @@ __all__ = [
     "muls",
     "adds",
     "cvt",
+    "quant",
     "subset",
 ]

--- a/ptodsl/api/type_def.py
+++ b/ptodsl/api/type_def.py
@@ -123,4 +123,6 @@ __all__ = [
     "int32",
     "ffts_type",
     "uint32",
+    "int8",
+    "uint8",
 ]

--- a/tests/npu/cvt_dynamic_multicore/compile.sh
+++ b/tests/npu/cvt_dynamic_multicore/compile.sh
@@ -3,7 +3,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 
 TMP=$(mktemp -d)
 trap "rm -rf $TMP" EXIT

--- a/tests/npu/elementwise_binary_dynamic_multicore/compile.sh
+++ b/tests/npu/elementwise_binary_dynamic_multicore/compile.sh
@@ -19,7 +19,7 @@ ptoas --enable-insert-sync "$TMP/${OP}_2d.pto" -o "$TMP/${OP}_2d.cpp"
 # Generate caller.cpp
 python "$SCRIPT_DIR/caller.py" "$OP" "$DTYPE" > "$TMP/caller.cpp"
 
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 bisheng \
     -I${PTO_LIB_PATH}/include \
     -fPIC -shared -D_FORTIFY_SOURCE=2 -O2 -std=c++17 \

--- a/tests/npu/elementwise_unary_dynamic_multicore/compile.sh
+++ b/tests/npu/elementwise_unary_dynamic_multicore/compile.sh
@@ -14,7 +14,7 @@ ptoas --enable-insert-sync "$TMP/${OP}_${DTYPE}.pto" -o "$TMP/${OP}_${DTYPE}.cpp
 
 python "$SCRIPT_DIR/caller.py" "$OP" "$DTYPE" > "$TMP/caller.cpp"
 
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 bisheng \
     -I${PTO_LIB_PATH}/include \
     -fPIC -shared -D_FORTIFY_SOURCE=2 -O2 -std=c++17 \

--- a/tests/npu/expand_dynamic_multicore/compile.sh
+++ b/tests/npu/expand_dynamic_multicore/compile.sh
@@ -7,7 +7,7 @@ TMP=$(mktemp -d)
 trap "rm -rf \"$TMP\"" EXIT
 
 
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 BISHENG_FLAGS=(
     -I${PTO_LIB_PATH}/include
     -fPIC -shared -D_FORTIFY_SOURCE=2 -O2 -std=c++17

--- a/tests/npu/gather_dynamic_multicore/compile.sh
+++ b/tests/npu/gather_dynamic_multicore/compile.sh
@@ -18,7 +18,7 @@ ptoas --enable-insert-sync "$TMP/${FN_NAME}.pto" -o "$TMP/${FN_NAME}.cpp"
 # Generate caller.cpp
 python "$SCRIPT_DIR/caller.py" "$DTYPE" "$MASK" > "$TMP/caller.cpp"
 
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 bisheng \
     -I${PTO_LIB_PATH}/include \
     -fPIC -shared -D_FORTIFY_SOURCE=2 -O2 -std=c++17 \

--- a/tests/npu/mrgsort_dynamic_multicore/compile.sh
+++ b/tests/npu/mrgsort_dynamic_multicore/compile.sh
@@ -15,7 +15,7 @@ ptoas --enable-insert-sync "$TMP/${FN_NAME}.pto" -o "$TMP/${FN_NAME}.cpp"
 
 python "$SCRIPT_DIR/caller.py" "$DTYPE" > "$TMP/caller.cpp"
 
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 bisheng \
     -I${PTO_LIB_PATH}/include \
     -fPIC -shared -D_FORTIFY_SOURCE=2 -O2 -std=c++17 \

--- a/tests/npu/quant_dynamic_multicore/builder.py
+++ b/tests/npu/quant_dynamic_multicore/builder.py
@@ -1,0 +1,260 @@
+from ptodsl import pto, tile, to_ir_module
+from ptodsl import scalar as s
+
+const = s.const
+
+_TILE_ROWS = 32
+_TILE_COLS = 32
+
+
+def build_sym_dynamic():
+    """Dynamic multicore symmetric quantization kernel.
+
+    Args:
+        src_ptr   : float32[batch, n_cols]  input
+        fp_ptr    : float32[batch, n_cols]  per-element scale factors
+        dst_ptr   : int8[batch, n_cols]     quantized output
+        batch     : int32
+        n_cols    : int32  (must be a multiple of _TILE_COLS = 32)
+
+    Semantics:
+        dst[i, j] = int8(round(src[i, j] * fp[i, j]))
+    """
+
+    def _meta():
+        return {
+            "ptr_f32": pto.PtrType(pto.float32),
+            "ptr_i8": pto.PtrType(pto.int8),
+            "index_dtype": pto.int32,
+            "tensor_f32": pto.TensorType(rank=2, dtype=pto.float32),
+            "tensor_i8": pto.TensorType(rank=2, dtype=pto.int8),
+            "sub_f32": pto.SubTensorType(
+                shape=[_TILE_ROWS, _TILE_COLS], dtype=pto.float32
+            ),
+            "sub_i8": pto.SubTensorType(shape=[_TILE_ROWS, _TILE_COLS], dtype=pto.int8),
+            "tile_f32": pto.TileBufType(
+                shape=[_TILE_ROWS, _TILE_COLS],
+                valid_shape=[-1, -1],
+                dtype=pto.float32,
+                memory_space="VEC",
+                config=pto.TileBufConfig(),
+            ),
+            "tile_i8": pto.TileBufType(
+                shape=[_TILE_ROWS, _TILE_COLS],
+                valid_shape=[-1, -1],
+                dtype=pto.int8,
+                memory_space="VEC",
+                config=pto.TileBufConfig(),
+            ),
+        }
+
+    @to_ir_module(meta_data=_meta)
+    def quant_sym_dynamic(
+        src_ptr: "ptr_f32",
+        fp_ptr: "ptr_f32",
+        dst_ptr: "ptr_i8",
+        batch_i32: "index_dtype",
+        n_cols_i32: "index_dtype",
+    ) -> None:
+        c0 = const(0)
+        c1 = const(1)
+        c_tile_rows = const(_TILE_ROWS)
+        c_tile_cols = const(_TILE_COLS)
+
+        batch = s.index_cast(batch_i32)
+        n_cols = s.index_cast(n_cols_i32)
+
+        with pto.vector_section():
+            bid = s.index_cast(pto.get_block_idx())
+            num_cores = s.index_cast(pto.get_block_num())
+
+            rows_per_core = s.ceil_div(batch, num_cores)
+            row_start = bid * rows_per_core
+            row_end = s.min_u(row_start + rows_per_core, batch)
+
+            tv_src = pto.as_tensor(
+                tensor_f32, ptr=src_ptr, shape=[batch, n_cols], strides=[n_cols, c1]
+            )
+            tv_fp = pto.as_tensor(
+                tensor_f32, ptr=fp_ptr, shape=[batch, n_cols], strides=[n_cols, c1]
+            )
+            tv_dst = pto.as_tensor(
+                tensor_i8, ptr=dst_ptr, shape=[batch, n_cols], strides=[n_cols, c1]
+            )
+
+            for row in pto.range(row_start, row_end, c_tile_rows):
+                rows_this = s.min_u(c_tile_rows, row_end - row)
+
+                for col in pto.range(c0, n_cols, c_tile_cols):
+                    tb_src = pto.alloc_tile(
+                        tile_f32, valid_row=rows_this, valid_col=c_tile_cols
+                    )
+                    tb_fp = pto.alloc_tile(
+                        tile_f32, valid_row=rows_this, valid_col=c_tile_cols
+                    )
+                    tb_dst = pto.alloc_tile(
+                        tile_i8, valid_row=rows_this, valid_col=c_tile_cols
+                    )
+
+                    sv_src = pto.slice_view(
+                        sub_f32,
+                        source=tv_src,
+                        offsets=[row, col],
+                        sizes=[rows_this, c_tile_cols],
+                    )
+                    sv_fp = pto.slice_view(
+                        sub_f32,
+                        source=tv_fp,
+                        offsets=[row, col],
+                        sizes=[rows_this, c_tile_cols],
+                    )
+                    sv_dst = pto.slice_view(
+                        sub_i8,
+                        source=tv_dst,
+                        offsets=[row, col],
+                        sizes=[rows_this, c_tile_cols],
+                    )
+
+                    pto.load(sv_src, tb_src)
+                    pto.load(sv_fp, tb_fp)
+                    tile.quant(tb_src, tb_fp, tb_dst, "int8_sym")
+                    pto.store(tb_dst, sv_dst)
+
+    return quant_sym_dynamic
+
+
+def build_asym_dynamic():
+    """Dynamic multicore asymmetric quantization kernel.
+
+    Args:
+        src_ptr    : float32[batch, n_cols]  input
+        fp_ptr     : float32[batch, n_cols]  per-element scale factors
+        offset_ptr : float32[batch, n_cols]  per-element offsets
+        dst_ptr    : uint8[batch, n_cols]    quantized output
+        batch      : int32
+        n_cols     : int32  (must be a multiple of _TILE_COLS = 32)
+
+    Semantics:
+        dst[i, j] = uint8(round(src[i, j] * fp[i, j]) + offset[i, j])
+    """
+
+    def _meta():
+        return {
+            "ptr_f32": pto.PtrType(pto.float32),
+            "ptr_u8": pto.PtrType(pto.uint8),
+            "index_dtype": pto.int32,
+            "tensor_f32": pto.TensorType(rank=2, dtype=pto.float32),
+            "tensor_u8": pto.TensorType(rank=2, dtype=pto.uint8),
+            "sub_f32": pto.SubTensorType(
+                shape=[_TILE_ROWS, _TILE_COLS], dtype=pto.float32
+            ),
+            "sub_u8": pto.SubTensorType(
+                shape=[_TILE_ROWS, _TILE_COLS], dtype=pto.uint8
+            ),
+            "tile_f32": pto.TileBufType(
+                shape=[_TILE_ROWS, _TILE_COLS],
+                valid_shape=[-1, -1],
+                dtype=pto.float32,
+                memory_space="VEC",
+                config=pto.TileBufConfig(),
+            ),
+            "tile_u8": pto.TileBufType(
+                shape=[_TILE_ROWS, _TILE_COLS],
+                valid_shape=[-1, -1],
+                dtype=pto.uint8,
+                memory_space="VEC",
+                config=pto.TileBufConfig(),
+            ),
+        }
+
+    @to_ir_module(meta_data=_meta)
+    def quant_asym_dynamic(
+        src_ptr: "ptr_f32",
+        fp_ptr: "ptr_f32",
+        offset_ptr: "ptr_f32",
+        dst_ptr: "ptr_u8",
+        batch_i32: "index_dtype",
+        n_cols_i32: "index_dtype",
+    ) -> None:
+        c0 = const(0)
+        c1 = const(1)
+        c_tile_rows = const(_TILE_ROWS)
+        c_tile_cols = const(_TILE_COLS)
+
+        batch = s.index_cast(batch_i32)
+        n_cols = s.index_cast(n_cols_i32)
+
+        with pto.vector_section():
+            bid = s.index_cast(pto.get_block_idx())
+            num_cores = s.index_cast(pto.get_block_num())
+
+            rows_per_core = s.ceil_div(batch, num_cores)
+            row_start = bid * rows_per_core
+            row_end = s.min_u(row_start + rows_per_core, batch)
+
+            tv_src = pto.as_tensor(
+                tensor_f32, ptr=src_ptr, shape=[batch, n_cols], strides=[n_cols, c1]
+            )
+            tv_fp = pto.as_tensor(
+                tensor_f32, ptr=fp_ptr, shape=[batch, n_cols], strides=[n_cols, c1]
+            )
+            tv_offset = pto.as_tensor(
+                tensor_f32, ptr=offset_ptr, shape=[batch, n_cols], strides=[n_cols, c1]
+            )
+            tv_dst = pto.as_tensor(
+                tensor_u8, ptr=dst_ptr, shape=[batch, n_cols], strides=[n_cols, c1]
+            )
+
+            for row in pto.range(row_start, row_end, c_tile_rows):
+                rows_this = s.min_u(c_tile_rows, row_end - row)
+
+                for col in pto.range(c0, n_cols, c_tile_cols):
+                    tb_src = pto.alloc_tile(
+                        tile_f32, valid_row=rows_this, valid_col=c_tile_cols
+                    )
+                    tb_fp = pto.alloc_tile(
+                        tile_f32, valid_row=rows_this, valid_col=c_tile_cols
+                    )
+                    tb_offset = pto.alloc_tile(
+                        tile_f32, valid_row=rows_this, valid_col=c_tile_cols
+                    )
+                    tb_dst = pto.alloc_tile(
+                        tile_u8, valid_row=rows_this, valid_col=c_tile_cols
+                    )
+
+                    sv_src = pto.slice_view(
+                        sub_f32,
+                        source=tv_src,
+                        offsets=[row, col],
+                        sizes=[rows_this, c_tile_cols],
+                    )
+                    sv_fp = pto.slice_view(
+                        sub_f32,
+                        source=tv_fp,
+                        offsets=[row, col],
+                        sizes=[rows_this, c_tile_cols],
+                    )
+                    sv_offset = pto.slice_view(
+                        sub_f32,
+                        source=tv_offset,
+                        offsets=[row, col],
+                        sizes=[rows_this, c_tile_cols],
+                    )
+                    sv_dst = pto.slice_view(
+                        sub_u8,
+                        source=tv_dst,
+                        offsets=[row, col],
+                        sizes=[rows_this, c_tile_cols],
+                    )
+
+                    pto.load(sv_src, tb_src)
+                    pto.load(sv_fp, tb_fp)
+                    pto.load(sv_offset, tb_offset)
+                    tile.quant(tb_src, tb_fp, tb_dst, "int8_asym", offset=tb_offset)
+                    pto.store(tb_dst, sv_dst)
+
+    return quant_asym_dynamic
+
+
+if __name__ == "__main__":
+    print(build_sym_dynamic())

--- a/tests/npu/quant_dynamic_multicore/caller.py
+++ b/tests/npu/quant_dynamic_multicore/caller.py
@@ -1,0 +1,61 @@
+"""Generate caller.cpp for quant dynamic multicore kernels."""
+
+import sys
+
+_BLOCK_DIM = 20
+
+
+def generate_caller(variant):
+    stem = f"quant_{variant}_dynamic"
+    fn_name = f"call_{stem}"
+    if variant == "sym":
+        return f"""\
+#include "{stem}.cpp"
+
+extern "C" void {fn_name}(
+    void *stream,
+    uint8_t *src,
+    uint8_t *fp,
+    uint8_t *dst,
+    int32_t batch,
+    int32_t n_cols)
+{{
+    quant_sym_dynamic<<<{_BLOCK_DIM}, nullptr, stream>>>(
+        reinterpret_cast<float *>(src),
+        reinterpret_cast<float *>(fp),
+        reinterpret_cast<int8_t *>(dst),
+        batch,
+        n_cols);
+}}
+"""
+    elif variant == "asym":
+        return f"""\
+#include "{stem}.cpp"
+
+extern "C" void {fn_name}(
+    void *stream,
+    uint8_t *src,
+    uint8_t *fp,
+    uint8_t *offset,
+    uint8_t *dst,
+    int32_t batch,
+    int32_t n_cols)
+{{
+    quant_asym_dynamic<<<{_BLOCK_DIM}, nullptr, stream>>>(
+        reinterpret_cast<float *>(src),
+        reinterpret_cast<float *>(fp),
+        reinterpret_cast<float *>(offset),
+        reinterpret_cast<uint8_t *>(dst),
+        batch,
+        n_cols);
+}}
+"""
+    else:
+        raise ValueError(f"Unknown variant: {variant!r}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python caller.py <sym|asym>", file=sys.stderr)
+        sys.exit(1)
+    print(generate_caller(sys.argv[1]))

--- a/tests/npu/quant_dynamic_multicore/caller.py
+++ b/tests/npu/quant_dynamic_multicore/caller.py
@@ -2,8 +2,6 @@
 
 import sys
 
-_BLOCK_DIM = 20
-
 
 def generate_caller(variant):
     stem = f"quant_{variant}_dynamic"
@@ -13,6 +11,7 @@ def generate_caller(variant):
 #include "{stem}.cpp"
 
 extern "C" void {fn_name}(
+    uint32_t blockDim,
     void *stream,
     uint8_t *src,
     uint8_t *fp,
@@ -20,7 +19,7 @@ extern "C" void {fn_name}(
     int32_t batch,
     int32_t n_cols)
 {{
-    quant_sym_dynamic<<<{_BLOCK_DIM}, nullptr, stream>>>(
+    quant_sym_dynamic<<<blockDim, nullptr, stream>>>(
         reinterpret_cast<float *>(src),
         reinterpret_cast<float *>(fp),
         reinterpret_cast<int8_t *>(dst),
@@ -33,6 +32,7 @@ extern "C" void {fn_name}(
 #include "{stem}.cpp"
 
 extern "C" void {fn_name}(
+    uint32_t blockDim,
     void *stream,
     uint8_t *src,
     uint8_t *fp,
@@ -41,7 +41,7 @@ extern "C" void {fn_name}(
     int32_t batch,
     int32_t n_cols)
 {{
-    quant_asym_dynamic<<<{_BLOCK_DIM}, nullptr, stream>>>(
+    quant_asym_dynamic<<<blockDim, nullptr, stream>>>(
         reinterpret_cast<float *>(src),
         reinterpret_cast<float *>(fp),
         reinterpret_cast<float *>(offset),

--- a/tests/npu/quant_dynamic_multicore/compile.sh
+++ b/tests/npu/quant_dynamic_multicore/compile.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PTO_LIB_PATH=/sources/pto-isa
+
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+
+_bisheng() {
+    bisheng \
+        -I${PTO_LIB_PATH}/include \
+        -fPIC -shared -D_FORTIFY_SOURCE=2 -O2 -std=c++17 \
+        -Wno-macro-redefined -Wno-ignored-attributes -fstack-protector-strong \
+        -xcce -Xhost-start -Xhost-end \
+        -mllvm -cce-aicore-stack-size=0x8000 \
+        -mllvm -cce-aicore-function-stack-size=0x8000 \
+        -mllvm -cce-aicore-record-overflow=true \
+        -mllvm -cce-aicore-addr-transform \
+        -mllvm -cce-aicore-dcci-insert-for-scalar=false \
+        --npu-arch=dav-2201 -DMEMORY_BASE \
+        -std=gnu++17 \
+        "$@"
+}
+
+compile_kernel() {
+    local VARIANT=$1
+    local STEM="quant_${VARIANT}_dynamic"
+
+    python "$SCRIPT_DIR/gen_ir.py" "$VARIANT" > "$TMP/${STEM}.pto"
+    ptoas --enable-insert-sync "$TMP/${STEM}.pto" -o "$TMP/${STEM}.cpp"
+    python "$SCRIPT_DIR/caller.py" "$VARIANT" > "$TMP/caller_${STEM}.cpp"
+    _bisheng "$TMP/caller_${STEM}.cpp" -o "$SCRIPT_DIR/${STEM}_lib.so"
+    echo "Built ${STEM}_lib.so"
+}
+
+compile_kernel sym
+compile_kernel asym

--- a/tests/npu/quant_dynamic_multicore/compile.sh
+++ b/tests/npu/quant_dynamic_multicore/compile.sh
@@ -3,7 +3,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 
 TMP=$(mktemp -d)
 trap "rm -rf $TMP" EXIT

--- a/tests/npu/quant_dynamic_multicore/gen_ir.py
+++ b/tests/npu/quant_dynamic_multicore/gen_ir.py
@@ -1,0 +1,31 @@
+"""Emit MLIR IR for a quant kernel.
+
+Usage:
+  python gen_ir.py sym
+  python gen_ir.py asym
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from builder import build_sym_dynamic, build_asym_dynamic
+
+_BUILDERS = {
+    "sym": build_sym_dynamic,
+    "asym": build_asym_dynamic,
+}
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python gen_ir.py <sym|asym>", file=sys.stderr)
+        sys.exit(1)
+    variant = sys.argv[1]
+    if variant not in _BUILDERS:
+        print(
+            f"Unknown variant: {variant!r}. Choose from: {list(_BUILDERS)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    print(_BUILDERS[variant]())

--- a/tests/npu/quant_dynamic_multicore/test_quant_dynamic.py
+++ b/tests/npu/quant_dynamic_multicore/test_quant_dynamic.py
@@ -5,10 +5,11 @@ import subprocess
 import pytest
 import torch
 
-from ptodsl.test_util import get_test_device
+from ptodsl.npu_info import get_num_cube_cores, get_test_device
 
 _DIR = os.path.dirname(os.path.abspath(__file__))
 _DEVICE = get_test_device()
+_BLOCK_DIM = get_num_cube_cores()
 
 VARIANTS = ["sym", "asym"]
 _PARAMS = [pytest.param(v, id=v) for v in VARIANTS]
@@ -53,6 +54,7 @@ def _load_sym_kernel():
     lib = ctypes.CDLL(_lib_path("sym"))
     fn = lib.call_quant_sym_dynamic
     fn.argtypes = [
+        ctypes.c_uint32,  # blockDim
         ctypes.c_void_p,  # stream
         ctypes.c_void_p,  # src
         ctypes.c_void_p,  # fp (inv_scale, broadcast per-row)
@@ -68,6 +70,7 @@ def _load_asym_kernel():
     lib = ctypes.CDLL(_lib_path("asym"))
     fn = lib.call_quant_asym_dynamic
     fn.argtypes = [
+        ctypes.c_uint32,  # blockDim
         ctypes.c_void_p,  # stream
         ctypes.c_void_p,  # src
         ctypes.c_void_p,  # fp (inv_scale, broadcast per-row)
@@ -166,6 +169,7 @@ def test_quant_sym(compiled_libs, batch, n_cols):
 
     torch.npu.synchronize()
     fn(
+        ctypes.c_uint32(_BLOCK_DIM),
         stream_ptr,
         _ctypes_ptr(src_dev),
         _ctypes_ptr(inv_scale_dev),
@@ -204,6 +208,7 @@ def test_quant_asym(compiled_libs, batch, n_cols):
 
     torch.npu.synchronize()
     fn(
+        ctypes.c_uint32(_BLOCK_DIM),
         stream_ptr,
         _ctypes_ptr(src_dev),
         _ctypes_ptr(inv_scale_dev),

--- a/tests/npu/quant_dynamic_multicore/test_quant_dynamic.py
+++ b/tests/npu/quant_dynamic_multicore/test_quant_dynamic.py
@@ -1,0 +1,228 @@
+import ctypes
+import os
+import subprocess
+
+import pytest
+import torch
+
+from ptodsl.test_util import get_test_device
+
+_DIR = os.path.dirname(os.path.abspath(__file__))
+_DEVICE = get_test_device()
+
+VARIANTS = ["sym", "asym"]
+_PARAMS = [pytest.param(v, id=v) for v in VARIANTS]
+
+# Shapes: (batch, n_cols). n_cols must be a multiple of builder._TILE_COLS (32).
+_SHAPES = [
+    (4, 32),
+    (7, 64),
+    (32, 32),
+    (32, 128),
+    (128, 128),
+    (15, 96),
+    (33, 128),
+]
+_SHAPE_IDS = [f"batch{b}-cols{c}" for b, c in _SHAPES]
+
+
+def _lib_path(variant):
+    return os.path.join(_DIR, f"quant_{variant}_dynamic_lib.so")
+
+
+def _ctypes_ptr(tensor):
+    return ctypes.c_void_p(tensor.data_ptr())
+
+
+@pytest.fixture(scope="session")
+def compiled_libs():
+    subprocess.check_call(["bash", os.path.join(_DIR, "compile.sh")], cwd=_DIR)
+    yield
+    for v in VARIANTS:
+        path = _lib_path(v)
+        if os.path.exists(path):
+            os.remove(path)
+
+
+@pytest.mark.parametrize("variant", _PARAMS)
+def test_build(compiled_libs, variant):
+    assert os.path.exists(_lib_path(variant))
+
+
+def _load_sym_kernel():
+    lib = ctypes.CDLL(_lib_path("sym"))
+    fn = lib.call_quant_sym_dynamic
+    fn.argtypes = [
+        ctypes.c_void_p,  # stream
+        ctypes.c_void_p,  # src
+        ctypes.c_void_p,  # fp (inv_scale, broadcast per-row)
+        ctypes.c_void_p,  # dst
+        ctypes.c_int32,  # batch
+        ctypes.c_int32,  # n_cols
+    ]
+    fn.restype = None
+    return fn
+
+
+def _load_asym_kernel():
+    lib = ctypes.CDLL(_lib_path("asym"))
+    fn = lib.call_quant_asym_dynamic
+    fn.argtypes = [
+        ctypes.c_void_p,  # stream
+        ctypes.c_void_p,  # src
+        ctypes.c_void_p,  # fp (inv_scale, broadcast per-row)
+        ctypes.c_void_p,  # offset (zero_point, broadcast per-row)
+        ctypes.c_void_p,  # dst
+        ctypes.c_int32,  # batch
+        ctypes.c_int32,  # n_cols
+    ]
+    fn.restype = None
+    return fn
+
+
+def _golden_sym(src, inv_scale):
+    """Golden reference matching the hardware path.
+
+    Mirrors fp32_to_int8_sym in the reference golden script:
+      scaled    = src * inv_scale              (fp32)
+      rounded   = round(scaled)               (fp32)
+      via_fp16  = rounded.to(fp16)            (exact for integers in [-128,127])
+      dst       = clip(via_fp16, -128, 127)   (int8)
+    """
+    rounded = torch.round(src * inv_scale)
+    via_fp16 = rounded.to(torch.float16)
+    return via_fp16.clamp(-128, 127).to(torch.int8)
+
+
+def _golden_asym(src, inv_scale, zero_point):
+    """Golden reference matching the hardware path.
+
+    Mirrors fp32_to_int8_asym in the reference golden script:
+      scaled    = src * inv_scale + zero_point  (fp32)
+      rounded   = round(scaled)                (fp32)
+      via_fp16  = rounded.to(fp16)             (exact for integers in [0,255])
+      dst       = clip(via_fp16, 0, 255)       (uint8)
+    """
+    rounded = torch.round(src * inv_scale + zero_point)
+    via_fp16 = rounded.to(torch.float16)
+    return via_fp16.clamp(0, 255).to(torch.uint8)
+
+
+def _make_sym_inputs(batch, n_cols, seed):
+    """Generate src and a uniform per-tensor inv_scale tile.
+
+    Uses a single inv_scale = 127 / global_max_abs so that fp[i,j] is
+    identical for all elements. The hardware applies one scale per tile
+    operation (matching the C++ reference's [rows,1] ParaTile), so a
+    uniform fp tensor ensures the golden and hardware agree regardless of
+    how the scale is read from the tile.
+    """
+    g = torch.Generator()
+    g.manual_seed(seed)
+    src = torch.empty(batch, n_cols, dtype=torch.float32).uniform_(
+        -2.0, 2.0, generator=g
+    )
+    max_abs = float(src.abs().max().clamp(min=1e-7))
+    inv_scale = torch.full((batch, n_cols), 127.0 / max_abs, dtype=torch.float32)
+    return src, inv_scale
+
+
+def _make_asym_inputs(batch, n_cols, seed):
+    """Generate src and uniform per-tensor inv_scale + zero_point tiles.
+
+    Uses global min/max so that all fp[i,j] and offset[i,j] are identical.
+    See _make_sym_inputs for the rationale.
+    """
+    g = torch.Generator()
+    g.manual_seed(seed)
+    src = torch.empty(batch, n_cols, dtype=torch.float32).uniform_(
+        -2.0, 2.0, generator=g
+    )
+    src_min = float(src.min())
+    src_max = float(src.max())
+    scale = max((src_max - src_min) / 255.0, 1e-7)
+    inv_scale_val = 1.0 / scale
+    zero_point_val = float(torch.tensor(-src_min * inv_scale_val).round().clamp(0, 255))
+    inv_scale = torch.full((batch, n_cols), inv_scale_val, dtype=torch.float32)
+    zero_point = torch.full((batch, n_cols), zero_point_val, dtype=torch.float32)
+    return src, inv_scale, zero_point
+
+
+@pytest.mark.require_npu
+@pytest.mark.parametrize("batch, n_cols", _SHAPES, ids=_SHAPE_IDS)
+def test_quant_sym(compiled_libs, batch, n_cols):
+    import torch_npu  # noqa: F401
+
+    torch.npu.set_device(_DEVICE)
+    fn = _load_sym_kernel()
+    stream_ptr = torch.npu.current_stream()._as_parameter_
+
+    src, inv_scale = _make_sym_inputs(batch, n_cols, seed=42)
+    golden = _golden_sym(src, inv_scale)
+
+    src_dev = src.to(_DEVICE)
+    inv_scale_dev = inv_scale.to(_DEVICE)
+    dst_dev = torch.zeros(batch, n_cols, device=_DEVICE, dtype=torch.int8)
+
+    torch.npu.synchronize()
+    fn(
+        stream_ptr,
+        _ctypes_ptr(src_dev),
+        _ctypes_ptr(inv_scale_dev),
+        _ctypes_ptr(dst_dev),
+        ctypes.c_int32(batch),
+        ctypes.c_int32(n_cols),
+    )
+    torch.npu.synchronize()
+
+    got = dst_dev.cpu()
+    torch.testing.assert_close(
+        got.to(torch.int32),
+        golden.to(torch.int32),
+        atol=0,
+        rtol=0,
+        msg=f"sym batch={batch} n_cols={n_cols}",
+    )
+
+
+@pytest.mark.require_npu
+@pytest.mark.parametrize("batch, n_cols", _SHAPES, ids=_SHAPE_IDS)
+def test_quant_asym(compiled_libs, batch, n_cols):
+    import torch_npu  # noqa: F401
+
+    torch.npu.set_device(_DEVICE)
+    fn = _load_asym_kernel()
+    stream_ptr = torch.npu.current_stream()._as_parameter_
+
+    src, inv_scale, zero_point = _make_asym_inputs(batch, n_cols, seed=99)
+    golden = _golden_asym(src, inv_scale, zero_point)
+
+    src_dev = src.to(_DEVICE)
+    inv_scale_dev = inv_scale.to(_DEVICE)
+    zero_point_dev = zero_point.to(_DEVICE)
+    dst_dev = torch.zeros(batch, n_cols, device=_DEVICE, dtype=torch.uint8)
+
+    torch.npu.synchronize()
+    fn(
+        stream_ptr,
+        _ctypes_ptr(src_dev),
+        _ctypes_ptr(inv_scale_dev),
+        _ctypes_ptr(zero_point_dev),
+        _ctypes_ptr(dst_dev),
+        ctypes.c_int32(batch),
+        ctypes.c_int32(n_cols),
+    )
+    torch.npu.synchronize()
+
+    got = dst_dev.cpu()
+    torch.testing.assert_close(
+        got.to(torch.int32),
+        golden.to(torch.int32),
+        atol=0,
+        rtol=0,
+        msg=f"asym batch={batch} n_cols={n_cols}",
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/npu/reduce_dynamic_multicore/compile.sh
+++ b/tests/npu/reduce_dynamic_multicore/compile.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TMP=$(mktemp -d)
 trap "rm -rf \"$TMP\"" EXIT
 
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 
 BISHENG_FLAGS=(
     -I${PTO_LIB_PATH}/include

--- a/tests/npu/sort32_dynamic_multicore/compile.sh
+++ b/tests/npu/sort32_dynamic_multicore/compile.sh
@@ -15,7 +15,7 @@ ptoas --enable-insert-sync "$TMP/${FN_NAME}.pto" -o "$TMP/${FN_NAME}.cpp"
 
 python "$SCRIPT_DIR/caller.py" "$DTYPE" > "$TMP/caller.cpp"
 
-PTO_LIB_PATH=/sources/pto-isa
+PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}
 bisheng \
     -I${PTO_LIB_PATH}/include \
     -fPIC -shared -D_FORTIFY_SOURCE=2 -O2 -std=c++17 \


### PR DESCRIPTION
- tile.quant (ptodsl/api/tile.py): wraps TQuantOp for "int8_sym" (fp32 → int8) and "int8_asym" (fp32 → uint8) quantization
- quant_dynamic_multicore (tests/npu/quant_dynamic_multicore/): build + NPU precision tests for both variants over 7 shapes, with multicore distribution via get_block_idx/get_block_num and dynamic tile iteration
- examples/README.md: note that AOT examples require PTO_LIB_PATH, defaulting to /sources/pto-isa but overridable via export
- all `compile.sh` scripts in tests and examples now use `PTO_LIB_PATH=${PTO_LIB_PATH:-/sources/pto-isa}` so an exported value takes precedence over the default

Note:
This PR requires updated .whl for ptoas with TQuantOp and Quant Type bindings 
see https://github.com/zhangstevenunity/PTOAS/pull/393
and https://github.com/zhangstevenunity/PTOAS/pull/390