### PR TITLE
Tests and api for row and colexpand fused kernels

### DIFF
--- a/ptodsl/api/tile.py
+++ b/ptodsl/api/tile.py
@@ -127,6 +127,10 @@ def row_expand_div(src0, src1, dst):
     _pto.TRowExpandDivOp(src0=src0, src1=src1, dst=dst)
 
 
+def row_expand_add(src0, src1, dst):
+    _pto.TRowExpandAddOp(src0=src0, src1=src1, dst=dst)
+
+
 def row_expand_mul(src0, src1, dst):
     _pto.TRowExpandMulOp(src0=src0, src1=src1, dst=dst)
 
@@ -149,6 +153,26 @@ def col_prod(src, tmp, dst, is_binary=True):
 
 def col_expand(src, dst):
     _pto.TColExpandOp(src=src, dst=dst)
+
+
+def col_expand_sub(src0, src1, dst):
+    _pto.TColExpandSubOp(src0=src0, src1=src1, dst=dst)
+
+
+def col_expand_div(src0, src1, dst):
+    _pto.TColExpandDivOp(src0=src0, src1=src1, dst=dst)
+
+
+def col_expand_mul(src0, src1, dst):
+    _pto.TColExpandMulOp(src0=src0, src1=src1, dst=dst)
+
+
+def col_expand_min(src0, src1, dst):
+    _pto.TColExpandMinOp(src0=src0, src1=src1, dst=dst)
+
+
+def col_expand_max(src0, src1, dst):
+    _pto.TColExpandMaxOp(src0=src0, src1=src1, dst=dst)
 
 
 def mrgsort(src, dst, block_len):
@@ -227,6 +251,7 @@ __all__ = [
     "row_max",
     "row_prod",
     "row_expand",
+    "row_expand_add",
     "row_expand_sub",
     "row_expand_div",
     "row_expand_mul",
@@ -235,6 +260,11 @@ __all__ = [
     "col_max",
     "col_prod",
     "col_expand",
+    "col_expand_sub",
+    "col_expand_div",
+    "col_expand_mul",
+    "col_expand_min",
+    "col_expand_max",
     "mrgsort",
     "sort32",
     "cvt",

--- a/ptodsl/api/tile.py
+++ b/ptodsl/api/tile.py
@@ -147,8 +147,8 @@ def col_max(src, dst):
     _pto.TColMaxOp(src=src, dst=dst)
 
 
-def col_prod(src, tmp, dst, is_binary=True):
-    _pto.TColProdOp(src=src, dst=dst, tmp=tmp, isBinary=BoolAttr.get(is_binary))
+def col_prod(src, tmp, dst):
+    _pto.TColProdOp(src=src, dst=dst)
 
 
 def col_expand(src, dst):
@@ -173,6 +173,26 @@ def col_expand_min(src0, src1, dst):
 
 def col_expand_max(src0, src1, dst):
     _pto.TColExpandMaxOp(src0=src0, src1=src1, dst=dst)
+
+
+def col_expand_add(src0, src1, dst):
+    _pto.TColExpandAddOp(src0=src0, src1=src1, dst=dst)
+
+
+def col_expand_expdif(src0, src1, dst):
+    _pto.TColExpandExpdifOp(src0=src0, src1=src1, dst=dst)
+
+
+def row_expand_min(src0, src1, dst):
+    _pto.TRowExpandMinOp(src0=src0, src1=src1, dst=dst)
+
+
+def row_expand_max(src0, src1, dst):
+    _pto.TRowExpandMaxOp(src0=src0, src1=src1, dst=dst)
+
+
+def row_expand_expdif(src0, src1, dst):
+    _pto.TRowExpandExpdifOp(src0=src0, src1=src1, dst=dst)
 
 
 def mrgsort(src, dst, block_len):
@@ -265,6 +285,11 @@ __all__ = [
     "col_expand_mul",
     "col_expand_min",
     "col_expand_max",
+    "col_expand_add",
+    "col_expand_expdif",
+    "row_expand_min",
+    "row_expand_max",
+    "row_expand_expdif",
     "mrgsort",
     "sort32",
     "cvt",

--- a/tests/npu/expand_dynamic_multicore/caller.py
+++ b/tests/npu/expand_dynamic_multicore/caller.py
@@ -5,15 +5,20 @@ Usage:
 """
 
 _FUSED_MODES = {
+    "colexpand_add",
     "colexpand_sub",
     "colexpand_div",
     "colexpand_mul",
     "colexpand_min",
     "colexpand_max",
+    "colexpand_expdif",
     "rowexpand_add",
     "rowexpand_mul",
     "rowexpand_sub",
     "rowexpand_div",
+    "rowexpand_min",
+    "rowexpand_max",
+    "rowexpand_expdif",
 }
 
 
@@ -70,11 +75,16 @@ if __name__ == "__main__":
         "colexpand_mul",
         "colexpand_min",
         "colexpand_max",
+        "colexpand_add",
+        "colexpand_expdif",
         "rowexpand",
         "rowexpand_add",
         "rowexpand_mul",
         "rowexpand_sub",
         "rowexpand_div",
+        "rowexpand_min",
+        "rowexpand_max",
+        "rowexpand_expdif",
     ]
 
     parser = argparse.ArgumentParser()

--- a/tests/npu/expand_dynamic_multicore/caller.py
+++ b/tests/npu/expand_dynamic_multicore/caller.py
@@ -4,7 +4,17 @@ Usage:
   python caller.py --mode colexpand|rowexpand|rowexpand_mul|rowexpand_sub|rowexpand_div
 """
 
-_FUSED_MODES = {"rowexpand_mul", "rowexpand_sub", "rowexpand_div"}
+_FUSED_MODES = {
+    "colexpand_sub",
+    "colexpand_div",
+    "colexpand_mul",
+    "colexpand_min",
+    "colexpand_max",
+    "rowexpand_add",
+    "rowexpand_mul",
+    "rowexpand_sub",
+    "rowexpand_div",
+}
 
 
 def generate_caller(mode, dtype):
@@ -55,7 +65,13 @@ if __name__ == "__main__":
 
     MODES = [
         "colexpand",
+        "colexpand_sub",
+        "colexpand_div",
+        "colexpand_mul",
+        "colexpand_min",
+        "colexpand_max",
         "rowexpand",
+        "rowexpand_add",
         "rowexpand_mul",
         "rowexpand_sub",
         "rowexpand_div",

--- a/tests/npu/expand_dynamic_multicore/compile.sh
+++ b/tests/npu/expand_dynamic_multicore/compile.sh
@@ -29,11 +29,16 @@ MODES=(
     colexpand_mul
     colexpand_min
     colexpand_max
+    colexpand_add
+    colexpand_expdif
     rowexpand
     rowexpand_add
     rowexpand_mul
     rowexpand_sub
     rowexpand_div
+    rowexpand_min
+    rowexpand_max
+    rowexpand_expdif
 )
 
 for MODE in "${MODES[@]}"; do

--- a/tests/npu/expand_dynamic_multicore/compile.sh
+++ b/tests/npu/expand_dynamic_multicore/compile.sh
@@ -24,7 +24,13 @@ BISHENG_FLAGS=(
 
 MODES=(
     colexpand
+    colexpand_sub
+    colexpand_div
+    colexpand_mul
+    colexpand_min
+    colexpand_max
     rowexpand
+    rowexpand_add
     rowexpand_mul
     rowexpand_sub
     rowexpand_div

--- a/tests/npu/expand_dynamic_multicore/expand_builder.py
+++ b/tests/npu/expand_dynamic_multicore/expand_builder.py
@@ -209,11 +209,13 @@ def build_row_expand(dtype="fp32"):
 # src1 is a col-vector tile (valid_row=1, valid_col=cols_this)
 # so src1[0,j] = x[col+j] per the hardware op convention.
 _COL_EXPAND_FUSED_OPS = {
+    "colexpand_add": tile.col_expand_add,
     "colexpand_sub": tile.col_expand_sub,
     "colexpand_div": tile.col_expand_div,
     "colexpand_mul": tile.col_expand_mul,
     "colexpand_min": tile.col_expand_min,
     "colexpand_max": tile.col_expand_max,
+    "colexpand_expdif": tile.col_expand_expdif,
 }
 
 
@@ -341,6 +343,14 @@ def build_col_expand_max(dtype="fp32"):
     return _build_col_expand_fused("colexpand_max", dtype=dtype)
 
 
+def build_col_expand_add(dtype="fp32"):
+    return _build_col_expand_fused("colexpand_add", dtype=dtype)
+
+
+def build_col_expand_expdif(dtype="fp32"):
+    return _build_col_expand_fused("colexpand_expdif", dtype=dtype)
+
+
 # Fused row-expand ops: dst[i,j] = src0[i,j] op src1[0,i]
 # src1 is a row-vector tile (valid_row=1, valid_col=rows_this)
 # so src1[0,i] = x[row+i] per the hardware op convention.
@@ -349,6 +359,9 @@ _ROW_EXPAND_FUSED_OPS = {
     "rowexpand_mul": tile.row_expand_mul,
     "rowexpand_sub": tile.row_expand_sub,
     "rowexpand_div": tile.row_expand_div,
+    "rowexpand_min": tile.row_expand_min,
+    "rowexpand_max": tile.row_expand_max,
+    "rowexpand_expdif": tile.row_expand_expdif,
 }
 
 
@@ -473,6 +486,18 @@ def build_row_expand_div(dtype="fp32"):
     return _build_row_expand_fused("rowexpand_div", dtype=dtype)
 
 
+def build_row_expand_min(dtype="fp32"):
+    return _build_row_expand_fused("rowexpand_min", dtype=dtype)
+
+
+def build_row_expand_max(dtype="fp32"):
+    return _build_row_expand_fused("rowexpand_max", dtype=dtype)
+
+
+def build_row_expand_expdif(dtype="fp32"):
+    return _build_row_expand_fused("rowexpand_expdif", dtype=dtype)
+
+
 if __name__ == "__main__":
     import argparse
 
@@ -483,11 +508,16 @@ if __name__ == "__main__":
         "colexpand_mul",
         "colexpand_min",
         "colexpand_max",
+        "colexpand_add",
+        "colexpand_expdif",
         "rowexpand",
         "rowexpand_add",
         "rowexpand_mul",
         "rowexpand_sub",
         "rowexpand_div",
+        "rowexpand_min",
+        "rowexpand_max",
+        "rowexpand_expdif",
     ]
 
     parser = argparse.ArgumentParser()
@@ -502,11 +532,16 @@ if __name__ == "__main__":
         "colexpand_mul": build_col_expand_mul,
         "colexpand_min": build_col_expand_min,
         "colexpand_max": build_col_expand_max,
+        "colexpand_add": build_col_expand_add,
+        "colexpand_expdif": build_col_expand_expdif,
         "rowexpand": build_row_expand,
         "rowexpand_add": build_row_expand_add,
         "rowexpand_mul": build_row_expand_mul,
         "rowexpand_sub": build_row_expand_sub,
         "rowexpand_div": build_row_expand_div,
+        "rowexpand_min": build_row_expand_min,
+        "rowexpand_max": build_row_expand_max,
+        "rowexpand_expdif": build_row_expand_expdif,
     }
 
     print(builders[args.mode](dtype=args.dtype))

--- a/tests/npu/expand_dynamic_multicore/expand_builder.py
+++ b/tests/npu/expand_dynamic_multicore/expand_builder.py
@@ -21,10 +21,8 @@ def meta_data_expand(dtype="fp32"):
     subtensor_col_src = pto.SubTensorType(shape=[1, tile_cols], dtype=pto_dtype)
     # For row_expand: src slice is [tile_rows, 1] (one column of the input vector)
     subtensor_row_src = pto.SubTensorType(shape=[tile_rows, 1], dtype=pto_dtype)
-    # For fused row-expand: scalar slice [1, 1]
+    # For loading a single scalar element [1, 1]
     subtensor_scalar = pto.SubTensorType(shape=[1, 1], dtype=pto_dtype)
-    # For fused row-expand: single-row slice [1, tile_cols]
-    subtensor_row_dst = pto.SubTensorType(shape=[1, tile_cols], dtype=pto_dtype)
     # For loading/storing the 2D matrix
     subtensor_dst = pto.SubTensorType(shape=[tile_rows, tile_cols], dtype=pto_dtype)
 
@@ -44,7 +42,6 @@ def meta_data_expand(dtype="fp32"):
         "subtensor_col_src": subtensor_col_src,
         "subtensor_row_src": subtensor_row_src,
         "subtensor_scalar": subtensor_scalar,
-        "subtensor_row_dst": subtensor_row_dst,
         "subtensor_dst": subtensor_dst,
         "tile_type": tile_type,
         "tile_rows": tile_rows,
@@ -208,10 +205,147 @@ def build_row_expand(dtype="fp32"):
     return _kernel
 
 
+# Fused col-expand ops: dst[i,j] = src0[i,j] op src1[0,j]
+# src1 is a col-vector tile (valid_row=1, valid_col=cols_this)
+# so src1[0,j] = x[col+j] per the hardware op convention.
+_COL_EXPAND_FUSED_OPS = {
+    "colexpand_sub": tile.col_expand_sub,
+    "colexpand_div": tile.col_expand_div,
+    "colexpand_mul": tile.col_expand_mul,
+    "colexpand_min": tile.col_expand_min,
+    "colexpand_max": tile.col_expand_max,
+}
+
+
+def _build_col_expand_fused(kind, dtype="fp32"):
+    """
+    Fused col-expand: apply element-wise op between Y[i,j] and x[j].
+
+    Semantics:
+        colexpand_mul: Z[i,j] = Y[i,j] * x[j]
+        colexpand_sub: Z[i,j] = Y[i,j] - x[j]
+        colexpand_div: Z[i,j] = Y[i,j] / x[j]
+        colexpand_min: Z[i,j] = min(Y[i,j], x[j])
+        colexpand_max: Z[i,j] = max(Y[i,j], x[j])
+    """
+    col_op = _COL_EXPAND_FUSED_OPS[kind]
+    _meta_data = lambda: meta_data_expand(dtype=dtype)
+
+    @to_ir_module(meta_data=_meta_data)
+    def _kernel(
+        x_ptr: "ptr_type",
+        y_ptr: "ptr_type",
+        z_ptr: "ptr_type",
+        batch_i32: "index_dtype",
+        n_cols_i32: "index_dtype",
+    ) -> None:
+        c0 = const(0)
+        c1 = const(1)
+        c_tile_rows = const(tile_rows)
+        c_tile_cols = const(tile_cols)
+
+        batch = s.index_cast(batch_i32)
+        n_cols = s.index_cast(n_cols_i32)
+
+        with pto.vector_section():
+            bid = s.index_cast(pto.get_block_idx())
+            num_cores = s.index_cast(pto.get_block_num())
+
+            cols_per_core = s.ceil_div(n_cols, num_cores)
+            col_start = bid * cols_per_core
+            col_end = s.min_u(col_start + cols_per_core, n_cols)
+
+            # x[n_cols] represented as 2D [1, n_cols]
+            tv_x = pto.as_tensor(
+                tensor2d_type,
+                ptr=x_ptr,
+                shape=[c1, n_cols],
+                strides=[n_cols, c1],
+            )
+            # y[batch, n_cols] - input matrix (src0)
+            tv_y = pto.as_tensor(
+                tensor2d_type,
+                ptr=y_ptr,
+                shape=[batch, n_cols],
+                strides=[n_cols, c1],
+            )
+            # z[batch, n_cols] - output matrix (dst)
+            tv_z = pto.as_tensor(
+                tensor2d_type,
+                ptr=z_ptr,
+                shape=[batch, n_cols],
+                strides=[n_cols, c1],
+            )
+
+            for col in pto.range(col_start, col_end, c_tile_cols):
+                cols_this = s.min_u(c_tile_cols, col_end - col)
+
+                # Load x[col:col+cols_this] into a [1, cols_this] tile
+                tb_src1 = pto.alloc_tile(tile_type, valid_row=c1, valid_col=cols_this)
+                sv_x = pto.slice_view(
+                    subtensor_col_src,
+                    source=tv_x,
+                    offsets=[c0, col],
+                    sizes=[c1, cols_this],
+                )
+                pto.load(sv_x, tb_src1)
+
+                for row in pto.range(c0, batch, c_tile_rows):
+                    rows_this = s.min_u(c_tile_rows, batch - row)
+
+                    sv_y = pto.slice_view(
+                        subtensor_dst,
+                        source=tv_y,
+                        offsets=[row, col],
+                        sizes=[rows_this, cols_this],
+                    )
+                    sv_z = pto.slice_view(
+                        subtensor_dst,
+                        source=tv_z,
+                        offsets=[row, col],
+                        sizes=[rows_this, cols_this],
+                    )
+
+                    tb_src0 = pto.alloc_tile(
+                        tile_type, valid_row=rows_this, valid_col=cols_this
+                    )
+                    pto.load(sv_y, tb_src0)
+
+                    tb_dst = pto.alloc_tile(
+                        tile_type, valid_row=rows_this, valid_col=cols_this
+                    )
+                    col_op(tb_src0, tb_src1, tb_dst)
+
+                    pto.store(tb_dst, sv_z)
+
+    return _kernel
+
+
+def build_col_expand_sub(dtype="fp32"):
+    return _build_col_expand_fused("colexpand_sub", dtype=dtype)
+
+
+def build_col_expand_div(dtype="fp32"):
+    return _build_col_expand_fused("colexpand_div", dtype=dtype)
+
+
+def build_col_expand_mul(dtype="fp32"):
+    return _build_col_expand_fused("colexpand_mul", dtype=dtype)
+
+
+def build_col_expand_min(dtype="fp32"):
+    return _build_col_expand_fused("colexpand_min", dtype=dtype)
+
+
+def build_col_expand_max(dtype="fp32"):
+    return _build_col_expand_fused("colexpand_max", dtype=dtype)
+
+
 # Fused row-expand ops: dst[i,j] = src0[i,j] op src1[0,i]
 # src1 is a row-vector tile (valid_row=1, valid_col=rows_this)
 # so src1[0,i] = x[row+i] per the hardware op convention.
 _ROW_EXPAND_FUSED_OPS = {
+    "expand_add": tile.row_expand_add,
     "expand_mul": tile.row_expand_mul,
     "expand_sub": tile.row_expand_sub,
     "expand_div": tile.row_expand_div,
@@ -294,13 +428,13 @@ def _build_row_expand_fused(kind, dtype="fp32"):
                     cols_this = s.min_u(c_tile_cols, n_cols - col)
 
                     sv_y = pto.slice_view(
-                        subtensor_row_dst,
+                        subtensor_col_src,
                         source=tv_y,
                         offsets=[row, col],
                         sizes=[c1, cols_this],
                     )
                     sv_z = pto.slice_view(
-                        subtensor_row_dst,
+                        subtensor_col_src,
                         source=tv_z,
                         offsets=[row, col],
                         sizes=[c1, cols_this],
@@ -322,6 +456,10 @@ def _build_row_expand_fused(kind, dtype="fp32"):
     return _kernel
 
 
+def build_row_expand_add(dtype="fp32"):
+    return _build_row_expand_fused("expand_add", dtype=dtype)
+
+
 def build_row_expand_mul(dtype="fp32"):
     return _build_row_expand_fused("expand_mul", dtype=dtype)
 
@@ -339,7 +477,13 @@ if __name__ == "__main__":
 
     _MODES = [
         "colexpand",
+        "colexpand_sub",
+        "colexpand_div",
+        "colexpand_mul",
+        "colexpand_min",
+        "colexpand_max",
         "rowexpand",
+        "rowexpand_add",
         "rowexpand_mul",
         "rowexpand_sub",
         "rowexpand_div",
@@ -352,7 +496,13 @@ if __name__ == "__main__":
 
     builders = {
         "colexpand": build_col_expand,
+        "colexpand_sub": build_col_expand_sub,
+        "colexpand_div": build_col_expand_div,
+        "colexpand_mul": build_col_expand_mul,
+        "colexpand_min": build_col_expand_min,
+        "colexpand_max": build_col_expand_max,
         "rowexpand": build_row_expand,
+        "rowexpand_add": build_row_expand_add,
         "rowexpand_mul": build_row_expand_mul,
         "rowexpand_sub": build_row_expand_sub,
         "rowexpand_div": build_row_expand_div,

--- a/tests/npu/expand_dynamic_multicore/expand_builder.py
+++ b/tests/npu/expand_dynamic_multicore/expand_builder.py
@@ -60,8 +60,8 @@ def build_col_expand(dtype="fp32"):
 
     @to_ir_module(meta_data=_meta_data)
     def _kernel(
-        y_ptr: "ptr_type",
-        x_ptr: "ptr_type",
+        src_ptr: "ptr_type",
+        dst_ptr: "ptr_type",
         batch_i32: "index_dtype",
         n_cols_i32: "index_dtype",
     ) -> None:
@@ -81,16 +81,16 @@ def build_col_expand(dtype="fp32"):
             col_start = bid * cols_per_core
             col_end = s.min_u(col_start + cols_per_core, n_cols)
 
-            # y[n_cols] represented as 2D [1, n_cols] for uniform slice_view usage
-            tv_y = pto.as_tensor(
+            # src[n_cols] represented as 2D [1, n_cols] for uniform slice_view usage
+            tv_src = pto.as_tensor(
                 tensor2d_type,
-                ptr=y_ptr,
+                ptr=src_ptr,
                 shape=[c1, n_cols],
                 strides=[n_cols, c1],
             )
-            tv_x = pto.as_tensor(
+            tv_dst = pto.as_tensor(
                 tensor2d_type,
-                ptr=x_ptr,
+                ptr=dst_ptr,
                 shape=[batch, n_cols],
                 strides=[n_cols, c1],
             )
@@ -98,15 +98,15 @@ def build_col_expand(dtype="fp32"):
             for col in pto.range(col_start, col_end, c_tile_cols):
                 cols_this = s.min_u(c_tile_cols, col_end - col)
 
-                # Load one row of y into the src tile (valid_row=1)
+                # Load one row of src into the src tile (valid_row=1)
                 tb_src = pto.alloc_tile(tile_type, valid_row=c1, valid_col=cols_this)
-                sv_y = pto.slice_view(
+                sv_src = pto.slice_view(
                     subtensor_col_src,
-                    source=tv_y,
+                    source=tv_src,
                     offsets=[c0, col],
                     sizes=[c1, cols_this],
                 )
-                pto.load(sv_y, tb_src)
+                pto.load(sv_src, tb_src)
 
                 for row in pto.range(c0, batch, c_tile_rows):
                     rows_this = s.min_u(c_tile_rows, batch - row)
@@ -116,13 +116,13 @@ def build_col_expand(dtype="fp32"):
                     )
                     tile.col_expand(tb_src, tb_dst)
 
-                    sv_x = pto.slice_view(
+                    sv_dst = pto.slice_view(
                         subtensor_dst,
-                        source=tv_x,
+                        source=tv_dst,
                         offsets=[row, col],
                         sizes=[rows_this, cols_this],
                     )
-                    pto.store(tb_dst, sv_x)
+                    pto.store(tb_dst, sv_dst)
 
     return _kernel
 
@@ -345,10 +345,10 @@ def build_col_expand_max(dtype="fp32"):
 # src1 is a row-vector tile (valid_row=1, valid_col=rows_this)
 # so src1[0,i] = x[row+i] per the hardware op convention.
 _ROW_EXPAND_FUSED_OPS = {
-    "expand_add": tile.row_expand_add,
-    "expand_mul": tile.row_expand_mul,
-    "expand_sub": tile.row_expand_sub,
-    "expand_div": tile.row_expand_div,
+    "rowexpand_add": tile.row_expand_add,
+    "rowexpand_mul": tile.row_expand_mul,
+    "rowexpand_sub": tile.row_expand_sub,
+    "rowexpand_div": tile.row_expand_div,
 }
 
 
@@ -357,9 +357,10 @@ def _build_row_expand_fused(kind, dtype="fp32"):
     Fused row-expand: apply element-wise op between Y[i,j] and x[i].
 
     Semantics:
-        expand_mul: Y[i,j] *= x[i]
-        expand_sub: Y[i,j] -= x[i]
-        expand_div: Y[i,j] /= x[i]
+        expand_add: Z[i,j] = Y[i,j] + x[i]
+        expand_mul: Z[i,j] = Y[i,j] * x[i]
+        expand_sub: Z[i,j] = Y[i,j] - x[i]
+        expand_div: Z[i,j] = Y[i,j] / x[i]
 
     src1 tile is a scalar [1, 1]: src1[0,0] = x[row], one row at a time.
     """
@@ -457,19 +458,19 @@ def _build_row_expand_fused(kind, dtype="fp32"):
 
 
 def build_row_expand_add(dtype="fp32"):
-    return _build_row_expand_fused("expand_add", dtype=dtype)
+    return _build_row_expand_fused("rowexpand_add", dtype=dtype)
 
 
 def build_row_expand_mul(dtype="fp32"):
-    return _build_row_expand_fused("expand_mul", dtype=dtype)
+    return _build_row_expand_fused("rowexpand_mul", dtype=dtype)
 
 
 def build_row_expand_sub(dtype="fp32"):
-    return _build_row_expand_fused("expand_sub", dtype=dtype)
+    return _build_row_expand_fused("rowexpand_sub", dtype=dtype)
 
 
 def build_row_expand_div(dtype="fp32"):
-    return _build_row_expand_fused("expand_div", dtype=dtype)
+    return _build_row_expand_fused("rowexpand_div", dtype=dtype)
 
 
 if __name__ == "__main__":

--- a/tests/npu/expand_dynamic_multicore/gen_ir.py
+++ b/tests/npu/expand_dynamic_multicore/gen_ir.py
@@ -1,7 +1,7 @@
 """Print MLIR IR for dynamic multicore col/row expand kernels.
 
 Usage:
-  python gen_ir.py --mode colexpand|rowexpand|rowexpand_mul|rowexpand_sub|rowexpand_div
+  python gen_ir.py --mode colexpand|colexpand_sub|colexpand_div|colexpand_mul|colexpand_min|colexpand_max|rowexpand|rowexpand_mul|rowexpand_sub|rowexpand_div
 """
 
 import argparse
@@ -12,7 +12,13 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from expand_builder import (
     build_col_expand,
+    build_col_expand_div,
+    build_col_expand_max,
+    build_col_expand_min,
+    build_col_expand_mul,
+    build_col_expand_sub,
     build_row_expand,
+    build_row_expand_add,
     build_row_expand_div,
     build_row_expand_mul,
     build_row_expand_sub,
@@ -20,7 +26,13 @@ from expand_builder import (
 
 _BUILDERS = {
     "colexpand": build_col_expand,
+    "colexpand_sub": build_col_expand_sub,
+    "colexpand_div": build_col_expand_div,
+    "colexpand_mul": build_col_expand_mul,
+    "colexpand_min": build_col_expand_min,
+    "colexpand_max": build_col_expand_max,
     "rowexpand": build_row_expand,
+    "rowexpand_add": build_row_expand_add,
     "rowexpand_mul": build_row_expand_mul,
     "rowexpand_sub": build_row_expand_sub,
     "rowexpand_div": build_row_expand_div,

--- a/tests/npu/expand_dynamic_multicore/gen_ir.py
+++ b/tests/npu/expand_dynamic_multicore/gen_ir.py
@@ -12,7 +12,9 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from expand_builder import (
     build_col_expand,
+    build_col_expand_add,
     build_col_expand_div,
+    build_col_expand_expdif,
     build_col_expand_max,
     build_col_expand_min,
     build_col_expand_mul,
@@ -20,6 +22,9 @@ from expand_builder import (
     build_row_expand,
     build_row_expand_add,
     build_row_expand_div,
+    build_row_expand_expdif,
+    build_row_expand_max,
+    build_row_expand_min,
     build_row_expand_mul,
     build_row_expand_sub,
 )
@@ -31,11 +36,16 @@ _BUILDERS = {
     "colexpand_mul": build_col_expand_mul,
     "colexpand_min": build_col_expand_min,
     "colexpand_max": build_col_expand_max,
+    "colexpand_add": build_col_expand_add,
+    "colexpand_expdif": build_col_expand_expdif,
     "rowexpand": build_row_expand,
     "rowexpand_add": build_row_expand_add,
     "rowexpand_mul": build_row_expand_mul,
     "rowexpand_sub": build_row_expand_sub,
     "rowexpand_div": build_row_expand_div,
+    "rowexpand_min": build_row_expand_min,
+    "rowexpand_max": build_row_expand_max,
+    "rowexpand_expdif": build_row_expand_expdif,
 }
 
 if __name__ == "__main__":

--- a/tests/npu/expand_dynamic_multicore/test_expand.py
+++ b/tests/npu/expand_dynamic_multicore/test_expand.py
@@ -15,7 +15,13 @@ _BLOCK_DIM = 24
 
 _KERNELS = [
     "colexpand",
+    "colexpand_sub",
+    "colexpand_div",
+    "colexpand_mul",
+    "colexpand_min",
+    "colexpand_max",
     "rowexpand",
+    "rowexpand_add",
     "rowexpand_mul",
     "rowexpand_sub",
     "rowexpand_div",
@@ -48,7 +54,17 @@ def compiled_kernels():
             os.remove(path)
 
 
-_FUSED_KERNELS = {"rowexpand_mul", "rowexpand_sub", "rowexpand_div"}
+_FUSED_KERNELS = {
+    "colexpand_sub",
+    "colexpand_div",
+    "colexpand_mul",
+    "colexpand_min",
+    "colexpand_max",
+    "rowexpand_add",
+    "rowexpand_mul",
+    "rowexpand_sub",
+    "rowexpand_div",
+}
 
 
 def _load_kernel(name):
@@ -87,13 +103,24 @@ def _make_inputs(name, batch, n_cols, device):
         src = torch.randn(batch, device=device, dtype=torch.float32)
         dst = torch.zeros((batch, n_cols), device=device, dtype=torch.float32)
         return src, dst, None
+    if name == "colexpand_div":
+        # avoid division by zero: keep x away from 0
+        x = torch.empty(n_cols, device=device, dtype=torch.float32).uniform_(0.5, 1.5)
+        y = torch.randn(batch, n_cols, device=device, dtype=torch.float32)
+        z = torch.zeros((batch, n_cols), device=device, dtype=torch.float32)
+        return x, y, z
+    if name in {"colexpand_sub", "colexpand_mul", "colexpand_min", "colexpand_max"}:
+        x = torch.randn(n_cols, device=device, dtype=torch.float32)
+        y = torch.randn(batch, n_cols, device=device, dtype=torch.float32)
+        z = torch.zeros((batch, n_cols), device=device, dtype=torch.float32)
+        return x, y, z
     if name == "rowexpand_div":
         # avoid division by zero: keep x away from 0
         x = torch.empty(batch, device=device, dtype=torch.float32).uniform_(0.5, 1.5)
         y = torch.randn(batch, n_cols, device=device, dtype=torch.float32)
         z = torch.zeros((batch, n_cols), device=device, dtype=torch.float32)
         return x, y, z
-    # rowexpand_mul, rowexpand_sub
+    # rowexpand_add, rowexpand_mul, rowexpand_sub
     x = torch.randn(batch, device=device, dtype=torch.float32)
     y = torch.randn(batch, n_cols, device=device, dtype=torch.float32)
     z = torch.zeros((batch, n_cols), device=device, dtype=torch.float32)
@@ -103,8 +130,20 @@ def _make_inputs(name, batch, n_cols, device):
 def _reference(name, x, y):
     if name == "colexpand":
         return x.float().unsqueeze(0).expand_as(y)
+    if name == "colexpand_sub":
+        return y.float() - x.float().unsqueeze(0)
+    if name == "colexpand_div":
+        return y.float() / x.float().unsqueeze(0)
+    if name == "colexpand_mul":
+        return y.float() * x.float().unsqueeze(0)
+    if name == "colexpand_min":
+        return torch.minimum(y.float(), x.float().unsqueeze(0).expand_as(y))
+    if name == "colexpand_max":
+        return torch.maximum(y.float(), x.float().unsqueeze(0).expand_as(y))
     if name == "rowexpand":
         return x.float().unsqueeze(1).expand_as(y)
+    if name == "rowexpand_add":
+        return y.float() + x.float().unsqueeze(1)
     if name == "rowexpand_mul":
         return y.float() * x.float().unsqueeze(1)
     if name == "rowexpand_sub":
@@ -116,6 +155,8 @@ def _reference(name, x, y):
 
 def _tolerances(name):
     if name in {"colexpand", "rowexpand"}:
+        return {"atol": 0, "rtol": 0}
+    if name in {"colexpand_min", "colexpand_max"}:
         return {"atol": 0, "rtol": 0}
     return {"atol": 1e-4, "rtol": 1e-4}
 

--- a/tests/npu/expand_dynamic_multicore/test_expand.py
+++ b/tests/npu/expand_dynamic_multicore/test_expand.py
@@ -20,11 +20,16 @@ _KERNELS = [
     "colexpand_mul",
     "colexpand_min",
     "colexpand_max",
+    "colexpand_add",
+    "colexpand_expdif",
     "rowexpand",
     "rowexpand_add",
     "rowexpand_mul",
     "rowexpand_sub",
     "rowexpand_div",
+    "rowexpand_min",
+    "rowexpand_max",
+    "rowexpand_expdif",
 ]
 
 _LIB_PATHS = {name: os.path.join(_DIR, f"{name}_lib.so") for name in _KERNELS}
@@ -55,15 +60,20 @@ def compiled_kernels():
 
 
 _FUSED_KERNELS = {
+    "colexpand_add",
     "colexpand_sub",
     "colexpand_div",
     "colexpand_mul",
     "colexpand_min",
     "colexpand_max",
+    "colexpand_expdif",
     "rowexpand_add",
     "rowexpand_mul",
     "rowexpand_sub",
     "rowexpand_div",
+    "rowexpand_min",
+    "rowexpand_max",
+    "rowexpand_expdif",
 }
 
 
@@ -109,7 +119,14 @@ def _make_inputs(name, batch, n_cols, device):
         y = torch.randn(batch, n_cols, device=device, dtype=torch.float32)
         z = torch.zeros((batch, n_cols), device=device, dtype=torch.float32)
         return x, y, z
-    if name in {"colexpand_sub", "colexpand_mul", "colexpand_min", "colexpand_max"}:
+    if name in {
+        "colexpand_add",
+        "colexpand_sub",
+        "colexpand_mul",
+        "colexpand_min",
+        "colexpand_max",
+        "colexpand_expdif",
+    }:
         x = torch.randn(n_cols, device=device, dtype=torch.float32)
         y = torch.randn(batch, n_cols, device=device, dtype=torch.float32)
         z = torch.zeros((batch, n_cols), device=device, dtype=torch.float32)
@@ -120,7 +137,7 @@ def _make_inputs(name, batch, n_cols, device):
         y = torch.randn(batch, n_cols, device=device, dtype=torch.float32)
         z = torch.zeros((batch, n_cols), device=device, dtype=torch.float32)
         return x, y, z
-    # rowexpand_add, rowexpand_mul, rowexpand_sub
+    # rowexpand_add, rowexpand_mul, rowexpand_sub, rowexpand_min, rowexpand_max, rowexpand_expdif
     x = torch.randn(batch, device=device, dtype=torch.float32)
     y = torch.randn(batch, n_cols, device=device, dtype=torch.float32)
     z = torch.zeros((batch, n_cols), device=device, dtype=torch.float32)
@@ -140,6 +157,8 @@ def _reference(name, x, y):
         return torch.minimum(y.float(), x.float().unsqueeze(0).expand_as(y))
     if name == "colexpand_max":
         return torch.maximum(y.float(), x.float().unsqueeze(0).expand_as(y))
+    if name == "colexpand_add":
+        return y.float() + x.float().unsqueeze(0)
     if name == "rowexpand":
         return x.float().unsqueeze(1).expand_as(y)
     if name == "rowexpand_add":
@@ -150,13 +169,21 @@ def _reference(name, x, y):
         return y.float() - x.float().unsqueeze(1)
     if name == "rowexpand_div":
         return y.float() / x.float().unsqueeze(1)
+    if name == "rowexpand_min":
+        return torch.minimum(y.float(), x.float().unsqueeze(1).expand_as(y))
+    if name == "rowexpand_max":
+        return torch.maximum(y.float(), x.float().unsqueeze(1).expand_as(y))
+    if name == "colexpand_expdif":
+        return torch.exp(y.float() - x.float().unsqueeze(0))
+    if name == "rowexpand_expdif":
+        return torch.exp(y.float() - x.float().unsqueeze(1))
     raise ValueError(f"Unknown kernel: {name}")
 
 
 def _tolerances(name):
     if name in {"colexpand", "rowexpand"}:
         return {"atol": 0, "rtol": 0}
-    if name in {"colexpand_min", "colexpand_max"}:
+    if name in {"colexpand_min", "colexpand_max", "rowexpand_min", "rowexpand_max"}:
         return {"atol": 0, "rtol": 0}
     return {"atol": 1e-4, "rtol": 1e-4}
 

--- a/tests/npu/reduce_dynamic_multicore/caller.py
+++ b/tests/npu/reduce_dynamic_multicore/caller.py
@@ -34,11 +34,11 @@ if __name__ == "__main__":
         "rowsum",
         "rowmin",
         "rowmax",
-        # "rowprod",
+        "rowprod",
         "colsum",
         "colmin",
         "colmax",
-        # "colprod",
+        "colprod",
     ]
 
     parser = argparse.ArgumentParser()

--- a/tests/npu/reduce_dynamic_multicore/compile.sh
+++ b/tests/npu/reduce_dynamic_multicore/compile.sh
@@ -26,11 +26,11 @@ MODES=(
     rowsum
     rowmin
     rowmax
-    # rowprod
+    rowprod
     colsum
     colmin
     colmax
-    # colprod
+    colprod
 )
 
 for MODE in "${MODES[@]}"; do

--- a/tests/npu/reduce_dynamic_multicore/gen_ir.py
+++ b/tests/npu/reduce_dynamic_multicore/gen_ir.py
@@ -13,11 +13,11 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from reduce_builder import (
     build_colmax,
     build_colmin,
-    # build_colprod,
+    build_colprod,
     build_colsum,
     build_rowmax,
     build_rowmin,
-    # build_rowprod,
+    build_rowprod,
     build_rowsum,
 )
 
@@ -25,11 +25,11 @@ _BUILDERS = {
     "rowsum": build_rowsum,
     "rowmin": build_rowmin,
     "rowmax": build_rowmax,
-    # "rowprod": build_rowprod,
+    "rowprod": build_rowprod,
     "colsum": build_colsum,
     "colmin": build_colmin,
     "colmax": build_colmax,
-    # "colprod": build_colprod,
+    "colprod": build_colprod,
 }
 
 if __name__ == "__main__":

--- a/tests/npu/reduce_dynamic_multicore/test_reduce.py
+++ b/tests/npu/reduce_dynamic_multicore/test_reduce.py
@@ -17,11 +17,11 @@ _KERNELS = [
     "rowsum",
     "rowmin",
     "rowmax",
-    # "rowprod",
+    "rowprod",
     "colsum",
     "colmin",
     "colmax",
-    # "colprod",
+    "colprod",
 ]
 
 _LIB_PATHS = {name: os.path.join(_DIR, f"{name}_lib.so") for name in _KERNELS}


### PR DESCRIPTION
## Summary

Adds fused col-expand and row-expand ops, col/row product reductions, and fixes bugs in the row-expand kernel builder and tile API.

### New fused expand ops — `Z[i,j] = Y[i,j] OP x[j/i]`

**Col-expand** (broadcasts `x[j]` over rows):
`colexpand_add`, `colexpand_sub`, `colexpand_div`, `colexpand_mul`, `colexpand_min`, `colexpand_max`, `colexpand_expdif`

**Row-expand** (broadcasts `x[i]` over columns):
`rowexpand_add`, `rowexpand_sub`, `rowexpand_div`, `rowexpand_mul`, `rowexpand_min`, `rowexpand_max`, `rowexpand_expdif`

`*_expdif` computes `exp(Y[i,j] - x[j/i])`, backed by the native `TColExpandExpdifOp` / `TRowExpandExpdifOp`.

### New reduce ops

Enables `colprod` and `rowprod` in `reduce_dynamic_multicore` (builder already existed, was commented out everywhere).

### Bug fixes

- **`_build_row_expand_fused`** — scalar load used `subtensor_dst` (`[32,32]`) instead of `subtensor_scalar` (`[1,1]`); per-row slices of Y/Z used `subtensor_dst` instead of `subtensor_col_src` (`[1,32]`). Both caused MLIR verification failures.
- **`tile.col_prod`** — `TColProdOp` does not accept `tmp` or `isBinary` (unlike `TColSumOp`); removed both arguments to match the actual op signature.

### Files changed

- `ptodsl/api/tile.py` — new API wrappers for all added ops; fixed `col_prod`
- `tests/npu/expand_dynamic_multicore/` — `expand_builder.py`, `gen_ir.py`, `caller.py`, `compile.sh`, `test_expand.py`
- `tests/npu/reduce_dynamic_multicore/` — `gen_ir.py`, `caller.py`, `compile.sh`, `test_reduce.py`


