### PR TITLE
Frontend: auto-discover and compile-test DSL kernels with ptoas & bisheng

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,11 @@ jobs:
           fi
 
       - name: Run frontend tests
-        run: pytest -v ./tests/frontend
+        run: |
+          export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/Ascend/ascend-toolkit/latest/$(uname -i)-linux/devlib
+          pytest -v ./tests/frontend
+        env:
+          PTO_LIB_PATH: /sources/pto-isa
 
       - name: Run NPU build tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,14 +97,14 @@ jobs:
 
       - name: Run frontend tests
         run: |
-          export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/Ascend/ascend-toolkit/latest/$(uname -i)-linux/devlib
+          export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/$(uname -i)-linux/devlib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
           pytest -v ./tests/frontend
         env:
           PTO_LIB_PATH: /sources/pto-isa
 
       - name: Run NPU build tests
         run: |
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/$(uname -i)-linux/devlib
+          export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/$(uname -i)-linux/devlib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
           pytest -v -m "not require_npu" ./tests/npu
         env:
           TORCH_DEVICE_BACKEND_AUTOLOAD: "0"

--- a/conftest.py
+++ b/conftest.py
@@ -6,3 +6,11 @@ def pytest_configure(config):
         "markers",
         "require_npu: marks tests as requiring NPU hardware (deselect with '-m \"not require_npu\"')",
     )
+    config.addinivalue_line(
+        "markers",
+        "require_ptoas_cli: marks tests as requiring the ptoas CLI on PATH",
+    )
+    config.addinivalue_line(
+        "markers",
+        "require_bisheng: marks tests as requiring the bisheng compiler and PTO_LIB_PATH",
+    )

--- a/examples/aot/tpushpop/mix-kernel_mlir/run.py
+++ b/examples/aot/tpushpop/mix-kernel_mlir/run.py
@@ -6,7 +6,7 @@ import subprocess
 import torch
 import torch_npu  # noqa: F401
 
-from ptodsl.test_util import get_test_device
+from ptodsl.utils.npu_info import get_test_device
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_LIB_PATH = os.path.join(THIS_DIR, "build_artifacts", "tpushpop_mlir_lib.so")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 markers =
     require_npu: marks tests as requiring NPU hardware (deselect with '-m "not require_npu"')
+    require_ptoas_cli: marks tests as requiring the ptoas CLI on PATH
+    require_bisheng: marks tests as requiring the bisheng compiler and PTO_LIB_PATH

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,5 +5,15 @@ export PTODSL_TEST_DEVICE_ID=0
 pytest -v .
 ```
 
-Note: put all on-device tests in [npu](./npu) subdirectory. The other directories only need host CPU.
+## Test directories
+
+| Directory | Needs NPU? | Needs ptoas CLI? | Needs bisheng? | What it tests |
+|-----------|:----------:|:----------------:|:--------------:|---------------|
+| `frontend/` | No | No (auto-skips) | No (auto-skips) | Python DSL bindings, IR generation, ptoas assembly, bisheng compilation |
+| `npu/` | Yes (runtime) | Yes (build) | Yes (build) | On-device correctness, end-to-end |
+
+`frontend/test_compile.py` auto-discovers every `test_*_ir.py` sibling and runs ptoas/bisheng on them.
+Tests that need ptoas or bisheng are skipped automatically when the tools are not available.
+
+Note: put all on-device tests in [npu](./npu) subdirectory.
 If `PTODSL_TEST_DEVICE_ID` is not set, NPU tests default to `0` (resolved as `npu:0`) and print a warning.

--- a/tests/frontend/conftest.py
+++ b/tests/frontend/conftest.py
@@ -1,0 +1,104 @@
+"""Shared fixtures and helpers for frontend tests.
+
+Provides:
+* ``run_ptoas`` / ``run_bisheng`` helpers for compile-level tests.
+* Auto-skip logic for ``require_ptoas_cli`` and ``require_bisheng`` markers.
+"""
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Tool availability (evaluated once at collection time)
+# ---------------------------------------------------------------------------
+
+_PTOAS_BIN = shutil.which("ptoas")
+_BISHENG_BIN = shutil.which("bisheng")
+_PTO_LIB_PATH = os.environ.get("PTO_LIB_PATH", "/sources/pto-isa")
+
+
+def _ptoas_available():
+    return _PTOAS_BIN is not None
+
+
+def _bisheng_available():
+    return _BISHENG_BIN is not None and os.path.isdir(
+        os.path.join(_PTO_LIB_PATH, "include")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Marker-based auto-skip
+# ---------------------------------------------------------------------------
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        if "require_ptoas_cli" in item.keywords and not _ptoas_available():
+            item.add_marker(pytest.mark.skip(reason="ptoas CLI not found on PATH"))
+        if "require_bisheng" in item.keywords and not _bisheng_available():
+            item.add_marker(
+                pytest.mark.skip(
+                    reason="bisheng not found on PATH or PTO_LIB_PATH/include missing"
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def run_ptoas(pto_path, cpp_path, *, enable_insert_sync=True):
+    """Run ``ptoas`` to assemble *pto_path* → *cpp_path*.
+
+    Raises :class:`subprocess.CalledProcessError` on failure.
+    """
+    cmd = ["ptoas"]
+    if enable_insert_sync:
+        cmd.append("--enable-insert-sync")
+    cmd += [str(pto_path), "-o", str(cpp_path)]
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+
+def run_bisheng(caller_cpp, output_so, *, npu_arch="dav-2201", cwd=None):
+    """Run ``bisheng`` to compile *caller_cpp* → *output_so*.
+
+    Raises :class:`subprocess.CalledProcessError` on failure.
+    """
+    pto_isa = os.environ.get("PTO_LIB_PATH", "/sources/pto-isa")
+    cmd = [
+        "bisheng",
+        f"-I{pto_isa}/include",
+        "-fPIC",
+        "-shared",
+        "-D_FORTIFY_SOURCE=2",
+        "-O2",
+        "-std=c++17",
+        "-Wno-macro-redefined",
+        "-Wno-ignored-attributes",
+        "-fstack-protector-strong",
+        "-xcce",
+        "-Xhost-start",
+        "-Xhost-end",
+        "-mllvm",
+        "-cce-aicore-stack-size=0x8000",
+        "-mllvm",
+        "-cce-aicore-function-stack-size=0x8000",
+        "-mllvm",
+        "-cce-aicore-record-overflow=true",
+        "-mllvm",
+        "-cce-aicore-addr-transform",
+        "-mllvm",
+        "-cce-aicore-dcci-insert-for-scalar=false",
+        f"--npu-arch={npu_arch}",
+        "-DMEMORY_BASE",
+        "-std=gnu++17",
+        str(caller_cpp),
+        "-o",
+        str(output_so),
+    ]
+    subprocess.run(cmd, check=True, capture_output=True, text=True, cwd=cwd)

--- a/tests/frontend/conftest.py
+++ b/tests/frontend/conftest.py
@@ -1,104 +1,22 @@
-"""Shared fixtures and helpers for frontend tests.
+"""Shared pytest hooks for frontend tests.
 
-Provides:
-* ``run_ptoas`` / ``run_bisheng`` helpers for compile-level tests.
-* Auto-skip logic for ``require_ptoas_cli`` and ``require_bisheng`` markers.
+Auto-skip logic for ``require_ptoas_cli`` and ``require_bisheng`` markers.
+Actual tool helpers live in ``tooling.py`` to avoid ambiguous ``conftest``
+imports (the repo also has a root ``conftest.py``).
 """
-
-import os
-import shutil
-import subprocess
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Tool availability (evaluated once at collection time)
-# ---------------------------------------------------------------------------
-
-_PTOAS_BIN = shutil.which("ptoas")
-_BISHENG_BIN = shutil.which("bisheng")
-_PTO_LIB_PATH = os.environ.get("PTO_LIB_PATH", "/sources/pto-isa")
-
-
-def _ptoas_available():
-    return _PTOAS_BIN is not None
-
-
-def _bisheng_available():
-    return _BISHENG_BIN is not None and os.path.isdir(
-        os.path.join(_PTO_LIB_PATH, "include")
-    )
-
-
-# ---------------------------------------------------------------------------
-# Marker-based auto-skip
-# ---------------------------------------------------------------------------
+from tooling import ptoas_available, bisheng_available  # noqa: F811
 
 
 def pytest_collection_modifyitems(config, items):
     for item in items:
-        if "require_ptoas_cli" in item.keywords and not _ptoas_available():
+        if "require_ptoas_cli" in item.keywords and not ptoas_available():
             item.add_marker(pytest.mark.skip(reason="ptoas CLI not found on PATH"))
-        if "require_bisheng" in item.keywords and not _bisheng_available():
+        if "require_bisheng" in item.keywords and not bisheng_available():
             item.add_marker(
                 pytest.mark.skip(
                     reason="bisheng not found on PATH or PTO_LIB_PATH/include missing"
                 )
             )
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def run_ptoas(pto_path, cpp_path, *, enable_insert_sync=True):
-    """Run ``ptoas`` to assemble *pto_path* → *cpp_path*.
-
-    Raises :class:`subprocess.CalledProcessError` on failure.
-    """
-    cmd = ["ptoas"]
-    if enable_insert_sync:
-        cmd.append("--enable-insert-sync")
-    cmd += [str(pto_path), "-o", str(cpp_path)]
-    subprocess.run(cmd, check=True, capture_output=True, text=True)
-
-
-def run_bisheng(caller_cpp, output_so, *, npu_arch="dav-2201", cwd=None):
-    """Run ``bisheng`` to compile *caller_cpp* → *output_so*.
-
-    Raises :class:`subprocess.CalledProcessError` on failure.
-    """
-    pto_isa = os.environ.get("PTO_LIB_PATH", "/sources/pto-isa")
-    cmd = [
-        "bisheng",
-        f"-I{pto_isa}/include",
-        "-fPIC",
-        "-shared",
-        "-D_FORTIFY_SOURCE=2",
-        "-O2",
-        "-std=c++17",
-        "-Wno-macro-redefined",
-        "-Wno-ignored-attributes",
-        "-fstack-protector-strong",
-        "-xcce",
-        "-Xhost-start",
-        "-Xhost-end",
-        "-mllvm",
-        "-cce-aicore-stack-size=0x8000",
-        "-mllvm",
-        "-cce-aicore-function-stack-size=0x8000",
-        "-mllvm",
-        "-cce-aicore-record-overflow=true",
-        "-mllvm",
-        "-cce-aicore-addr-transform",
-        "-mllvm",
-        "-cce-aicore-dcci-insert-for-scalar=false",
-        f"--npu-arch={npu_arch}",
-        "-DMEMORY_BASE",
-        "-std=gnu++17",
-        str(caller_cpp),
-        "-o",
-        str(output_so),
-    ]
-    subprocess.run(cmd, check=True, capture_output=True, text=True, cwd=cwd)

--- a/tests/frontend/test_compile.py
+++ b/tests/frontend/test_compile.py
@@ -1,0 +1,204 @@
+"""Auto-discovered compile-level tests: ptoas assembly and bisheng compilation.
+
+These tests **automatically discover** DSL kernel definitions from sibling
+``test_*_ir.py`` modules and verify:
+
+1. DSL-generated ``.pto`` can be assembled to C++ by ``ptoas``.
+2. The ptoas C++ output + a caller wrapper compiles to ``.so`` via ``bisheng``.
+
+Neither step requires an NPU device — only the CLI tools that ship with the
+CANN image.
+
+Convention for auto-discovery
+-----------------------------
+Modules named ``test_*_ir.py`` in this directory are scanned at collection
+time.  Each module that defines a top-level ``meta_data()`` function is
+inspected.  Every other public, non-test, non-build function whose parameter
+annotations are all plain strings (PTO type aliases like ``"ptr_type"``) is
+treated as a DSL kernel.  Each one is wrapped with
+``to_ir_module(meta_data=meta_data)(fn)`` to produce a ``.pto`` module, then:
+
+1. The ``.pto`` is assembled to C++ by ``ptoas``.
+2. The ptoas C++ output + a caller wrapper compiles to ``.so`` via ``bisheng``.
+
+``--enable-insert-sync`` is enabled automatically unless the generated IR
+already contains explicit synchronisation ops (``record_event`` /
+``wait_event``).
+
+Raw MLIR ``build*()`` functions in the same modules are **not** picked up
+for compilation — they exist solely for IR-equality tests.
+
+To add a new op, create a ``test_<op>_ir.py`` that follows the pattern above.
+**No changes to this file are required.**
+"""
+
+import importlib
+import importlib.util
+import inspect
+import pathlib
+import sys
+
+import pytest
+
+from ptodsl import JitWrapper, to_ir_module
+
+from conftest import run_ptoas, run_bisheng
+
+_THIS_DIR = pathlib.Path(__file__).parent
+
+
+# ---------------------------------------------------------------------------
+# Discovery helpers
+# ---------------------------------------------------------------------------
+
+
+def _import_ir_modules():
+    """Import every ``test_*_ir.py`` sibling and return ``{stem: module}``."""
+    modules = {}
+    for path in sorted(_THIS_DIR.glob("test_*_ir.py")):
+        stem = path.stem
+        # Prefer the already-loaded module (pytest may have imported it).
+        if stem in sys.modules:
+            modules[stem] = sys.modules[stem]
+        else:
+            spec = importlib.util.spec_from_file_location(stem, path)
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules[stem] = mod
+            spec.loader.exec_module(mod)
+            modules[stem] = mod
+    return modules
+
+
+def _is_kernel_fn(fn, mod):
+    """Heuristic: *fn* is a PTO DSL kernel defined in *mod*."""
+    if not inspect.isfunction(fn):
+        return False
+    # Must be defined in *this* source file (filters out re-exports).
+    try:
+        fn_file = inspect.getfile(fn)
+    except TypeError:
+        return False
+    if fn_file != getattr(mod, "__file__", None):
+        return False
+    hints = getattr(fn, "__annotations__", {})
+    params = {k: v for k, v in hints.items() if k != "return"}
+    if not params:
+        return False
+    # All parameter annotations must be plain strings (PTO type aliases).
+    return all(isinstance(v, str) for v in params.values())
+
+
+def _has_manual_sync(ir_text: str) -> bool:
+    """``True`` when the IR contains explicit sync ops."""
+    return "record_event" in ir_text or "wait_event" in ir_text
+
+
+# ---------------------------------------------------------------------------
+# Collect cases at import time
+# ---------------------------------------------------------------------------
+
+# Each entry: (case_id, ir_factory, meta_fn, kernel_fn)
+_CASES: list[tuple] = []
+
+for _mod_name, _mod in _import_ir_modules().items():
+    _short = _mod_name.removeprefix("test_").removesuffix("_ir")
+
+    # -- DSL kernels: meta_data + annotated functions ----------------------
+    _meta = getattr(_mod, "meta_data", None)
+    if callable(_meta):
+        for _name, _obj in inspect.getmembers(_mod, inspect.isfunction):
+            if (
+                _name.startswith("_")
+                or _name.startswith("test_")
+                or _name.startswith("build")
+                or _name == "meta_data"
+            ):
+                continue
+            if _is_kernel_fn(_obj, _mod):
+                _cid = f"{_short}/{_name}"
+
+                # default-arg trick to capture the current loop values
+                def _make_dsl_factory(m=_meta, k=_obj):
+                    return to_ir_module(meta_data=m)(k)
+
+                _CASES.append((_cid, _make_dsl_factory, _meta, _obj))
+
+# -- Parametrise lists -----------------------------------------------------
+
+_PTOAS_PARAMS = [pytest.param(cid, factory, id=cid) for cid, factory, _, _ in _CASES]
+
+_BISHENG_PARAMS = [
+    pytest.param(cid, factory, meta, kern, id=cid)
+    for cid, factory, meta, kern in _CASES
+    if meta is not None and kern is not None
+]
+
+
+# ---------------------------------------------------------------------------
+# Caller-cpp helper (reuses JitWrapper internals)
+# ---------------------------------------------------------------------------
+
+
+def _caller_cpp(fn, meta_data_fn, kernel_cpp_name="kernel.cpp"):
+    """Use :class:`JitWrapper` internals to generate a ``caller.cpp`` string."""
+    wrapper = JitWrapper(fn, meta_data=meta_data_fn, block_dim=20)
+    wrapper._arg_types = wrapper._resolve_runtime_arg_types()
+    return wrapper._generate_caller_cpp(kernel_cpp_name)
+
+
+# ---------------------------------------------------------------------------
+# ptoas assembly tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.require_ptoas_cli
+@pytest.mark.parametrize("case_id,ir_factory", _PTOAS_PARAMS)
+def test_ptoas_assemble(case_id, ir_factory, tmp_path):
+    """``ptoas`` can assemble auto-discovered .pto into C++."""
+    ir_module = ir_factory()
+    ir_text = str(ir_module)
+    enable_sync = not _has_manual_sync(ir_text)
+
+    pto_path = tmp_path / "kernel.pto"
+    cpp_path = tmp_path / "kernel.cpp"
+    pto_path.write_text(ir_text + "\n", encoding="utf-8")
+
+    run_ptoas(pto_path, cpp_path, enable_insert_sync=enable_sync)
+
+    assert cpp_path.exists(), f"ptoas did not produce {cpp_path}"
+    content = cpp_path.read_text(encoding="utf-8")
+    assert len(content) > 0, "ptoas produced an empty C++ file"
+
+
+# ---------------------------------------------------------------------------
+# bisheng end-to-end compile tests  (ptoas → bisheng)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.require_ptoas_cli
+@pytest.mark.require_bisheng
+@pytest.mark.parametrize("case_id,ir_factory,meta_fn,kernel_fn", _BISHENG_PARAMS)
+def test_bisheng_compile(case_id, ir_factory, meta_fn, kernel_fn, tmp_path):
+    """Full pipeline: .pto → ptoas → .cpp → bisheng → .so"""
+    ir_module = ir_factory()
+    ir_text = str(ir_module)
+    enable_sync = not _has_manual_sync(ir_text)
+
+    pto_path = tmp_path / "kernel.pto"
+    cpp_path = tmp_path / "kernel.cpp"
+    caller_path = tmp_path / "caller.cpp"
+    so_path = tmp_path / "kernel.so"
+
+    # Step 1: ptoas
+    pto_path.write_text(ir_text + "\n", encoding="utf-8")
+    run_ptoas(pto_path, cpp_path, enable_insert_sync=enable_sync)
+
+    # Step 2: generate caller.cpp
+    caller_code = _caller_cpp(kernel_fn, meta_fn, kernel_cpp_name=cpp_path.name)
+    caller_path.write_text(caller_code, encoding="utf-8")
+
+    # Step 3: bisheng
+    run_bisheng(caller_path, so_path, cwd=str(tmp_path))
+
+    assert so_path.exists(), f"bisheng did not produce {so_path}"
+    assert so_path.stat().st_size > 0, "bisheng produced an empty .so"

--- a/tests/frontend/test_compile.py
+++ b/tests/frontend/test_compile.py
@@ -32,7 +32,6 @@ To add a new op, create a ``test_<op>_ir.py`` that follows the pattern above.
 **No changes to this file are required.**
 """
 
-import importlib
 import importlib.util
 import inspect
 import pathlib

--- a/tests/frontend/test_compile.py
+++ b/tests/frontend/test_compile.py
@@ -41,7 +41,7 @@ import pytest
 
 from ptodsl import JitWrapper, to_ir_module
 
-from conftest import run_ptoas, run_bisheng
+from tooling import run_ptoas, run_bisheng
 
 _THIS_DIR = pathlib.Path(__file__).parent
 

--- a/tests/frontend/test_matmul_dynamic_ir.py
+++ b/tests/frontend/test_matmul_dynamic_ir.py
@@ -19,184 +19,173 @@ def _idx_const(v: int):
     return arith.ConstantOp(IndexType.get(), v).result
 
 
-def build_pythonic(
-    M=128,
-    K=128,
-    N=128,
-    validM=128,
-    validK=128,
-    validN=128,
-    BASEK=32,
-):
-    assert K % BASEK == 0
-    iters = K // BASEK
+# ---------------------------------------------------------------------------
+# Default tile dimensions (shared by DSL kernel and MLIR reference builder)
+# ---------------------------------------------------------------------------
+M = 128
+K = 128
+N = 128
+validM = 128
+validK = 128
+validN = 128
+BASEK = 32
+_ITERS = K // BASEK
 
-    def meta_data():
-        dtype = pto.float32
-        ptr_dtype = pto.PtrType(dtype)
-        i1 = IntegerType.get_signless(1)
-        i32 = pto.int32
-        tensor_type = pto.TensorType(rank=2, dtype=dtype)
+const = s.const
 
-        tile_view_a = pto.SubTensorType(shape=[M, BASEK], dtype=dtype)
-        tile_view_b = pto.SubTensorType(shape=[BASEK, N], dtype=dtype)
-        tile_view_out = pto.SubTensorType(shape=[M, N], dtype=dtype)
-        tile_view_bias = pto.SubTensorType(shape=[1, N], dtype=dtype)
 
-        tile_buf_aMat = pto.TileBufType(
-            shape=[M, BASEK], dtype=dtype, memory_space="MAT"
+def meta_data():
+    dtype = pto.float32
+    ptr_dtype = pto.PtrType(dtype)
+    i1 = pto.bool
+    i32 = pto.int32
+    tensor_type = pto.TensorType(rank=2, dtype=dtype)
+
+    tile_view_a = pto.SubTensorType(shape=[M, BASEK], dtype=dtype)
+    tile_view_b = pto.SubTensorType(shape=[BASEK, N], dtype=dtype)
+    tile_view_out = pto.SubTensorType(shape=[M, N], dtype=dtype)
+    tile_view_bias = pto.SubTensorType(shape=[1, N], dtype=dtype)
+
+    tile_buf_aMat = pto.TileBufType(shape=[M, BASEK], dtype=dtype, memory_space="MAT")
+    tile_buf_bMat = pto.TileBufType(shape=[BASEK, N], dtype=dtype, memory_space="MAT")
+    tile_buf_biasData = pto.TileBufType(shape=[1, N], dtype=dtype, memory_space="MAT")
+    tile_buf_aTile = pto.TileBufType(shape=[M, BASEK], dtype=dtype, memory_space="LEFT")
+    tile_buf_bTile = pto.TileBufType(
+        shape=[BASEK, N], dtype=dtype, memory_space="RIGHT"
+    )
+    tile_buf_cTile = pto.TileBufType(shape=[M, N], dtype=dtype, memory_space="ACC")
+    tile_buf_biasTile = pto.TileBufType(shape=[1, N], dtype=dtype, memory_space="BIAS")
+
+    return {
+        "ptr_type": ptr_dtype,
+        "i1": i1,
+        "i32": i32,
+        "tensor_type": tensor_type,
+        "tile_view_a": tile_view_a,
+        "tile_view_b": tile_view_b,
+        "tile_view_out": tile_view_out,
+        "tile_view_bias": tile_view_bias,
+        "tile_buf_aMat": tile_buf_aMat,
+        "tile_buf_bMat": tile_buf_bMat,
+        "tile_buf_biasData": tile_buf_biasData,
+        "tile_buf_aTile": tile_buf_aTile,
+        "tile_buf_bTile": tile_buf_bTile,
+        "tile_buf_cTile": tile_buf_cTile,
+        "tile_buf_biasTile": tile_buf_biasTile,
+    }
+
+
+def RunTMATMULSplitK(
+    out_ptr: "ptr_type",
+    a_ptr: "ptr_type",
+    b_ptr: "ptr_type",
+    bias_ptr: "ptr_type",
+    isBias: "i1",
+    batch_i32: "i32",
+) -> None:
+    with pto.cube_section():
+        c0 = const(0)
+        c1 = const(1)
+        cM = const(validM)
+        cK = const(validK)
+        cN = const(validN)
+        cBASEK = const(BASEK)
+        cIter = const(_ITERS)
+        cTileM = const(M)
+        cTileN = const(N)
+
+        batch = s.index_cast(batch_i32)
+        cBM = batch * cM
+
+        num_blocks = s.index_cast(pto.get_block_num())
+        batches_per_core = s.ceil_div(batch, num_blocks)
+        bid = s.index_cast(pto.get_block_idx())
+        b_start = bid * batches_per_core
+        b_end_unclamped = b_start + batches_per_core
+        b_end = s.min_u(b_end_unclamped, batch)
+
+        tvA = pto.as_tensor(tensor_type, ptr=a_ptr, shape=[cBM, cK], strides=[cK, c1])
+        tvB = pto.as_tensor(tensor_type, ptr=b_ptr, shape=[cK, cN], strides=[cN, c1])
+        tvOut = pto.as_tensor(
+            tensor_type, ptr=out_ptr, shape=[cBM, cN], strides=[cN, c1]
         )
-        tile_buf_bMat = pto.TileBufType(
-            shape=[BASEK, N], dtype=dtype, memory_space="MAT"
-        )
-        tile_buf_biasData = pto.TileBufType(
-            shape=[1, N], dtype=dtype, memory_space="MAT"
-        )
-        tile_buf_aTile = pto.TileBufType(
-            shape=[M, BASEK], dtype=dtype, memory_space="LEFT"
-        )
-        tile_buf_bTile = pto.TileBufType(
-            shape=[BASEK, N], dtype=dtype, memory_space="RIGHT"
-        )
-        tile_buf_cTile = pto.TileBufType(shape=[M, N], dtype=dtype, memory_space="ACC")
-        tile_buf_biasTile = pto.TileBufType(
-            shape=[1, N], dtype=dtype, memory_space="BIAS"
+        tvBias = pto.as_tensor(
+            tensor_type, ptr=bias_ptr, shape=[c1, cN], strides=[cN, c1]
         )
 
-        return {
-            "ptr_type": ptr_dtype,
-            "i1": i1,
-            "i32": i32,
-            "tensor_type": tensor_type,
-            "tile_view_a": tile_view_a,
-            "tile_view_b": tile_view_b,
-            "tile_view_out": tile_view_out,
-            "tile_view_bias": tile_view_bias,
-            "tile_buf_aMat": tile_buf_aMat,
-            "tile_buf_bMat": tile_buf_bMat,
-            "tile_buf_biasData": tile_buf_biasData,
-            "tile_buf_aTile": tile_buf_aTile,
-            "tile_buf_bTile": tile_buf_bTile,
-            "tile_buf_cTile": tile_buf_cTile,
-            "tile_buf_biasTile": tile_buf_biasTile,
-        }
+        aMatTile = pto.alloc_tile(tile_buf_aMat)
+        bMatTile = pto.alloc_tile(tile_buf_bMat)
+        biasDataTile = pto.alloc_tile(tile_buf_biasData)
+        aTile = pto.alloc_tile(tile_buf_aTile)
+        bTile = pto.alloc_tile(tile_buf_bTile)
+        cTile = pto.alloc_tile(tile_buf_cTile)
+        biasTile = pto.alloc_tile(tile_buf_biasTile)
 
-    const = s.const
-
-    @to_ir_module(meta_data=meta_data)
-    def RunTMATMULSplitK(
-        out_ptr: "ptr_type",
-        a_ptr: "ptr_type",
-        b_ptr: "ptr_type",
-        bias_ptr: "ptr_type",
-        isBias: "i1",
-        batch_i32: "i32",
-    ) -> None:
-        with pto.cube_section():
-            c0 = const(0)
-            c1 = const(1)
-            cM = const(validM)
-            cK = const(validK)
-            cN = const(validN)
-            cBASEK = const(BASEK)
-            cIter = const(iters)
-            cTileM = const(M)
-            cTileN = const(N)
-
-            batch = s.index_cast(batch_i32)
-            cBM = batch * cM
-
-            num_blocks = s.index_cast(pto.get_block_num())
-            batches_per_core = s.ceil_div(batch, num_blocks)
-            bid = s.index_cast(pto.get_block_idx())
-            b_start = bid * batches_per_core
-            b_end_unclamped = b_start + batches_per_core
-            b_end = s.min_u(b_end_unclamped, batch)
-
-            tvA = pto.as_tensor(
-                tensor_type, ptr=a_ptr, shape=[cBM, cK], strides=[cK, c1]
-            )
-            tvB = pto.as_tensor(
-                tensor_type, ptr=b_ptr, shape=[cK, cN], strides=[cN, c1]
-            )
-            tvOut = pto.as_tensor(
-                tensor_type, ptr=out_ptr, shape=[cBM, cN], strides=[cN, c1]
-            )
-            tvBias = pto.as_tensor(
-                tensor_type, ptr=bias_ptr, shape=[c1, cN], strides=[cN, c1]
-            )
-
-            aMatTile = pto.alloc_tile(tile_buf_aMat)
-            bMatTile = pto.alloc_tile(tile_buf_bMat)
-            biasDataTile = pto.alloc_tile(tile_buf_biasData)
-            aTile = pto.alloc_tile(tile_buf_aTile)
-            bTile = pto.alloc_tile(tile_buf_bTile)
-            cTile = pto.alloc_tile(tile_buf_cTile)
-            biasTile = pto.alloc_tile(tile_buf_biasTile)
-
-            for b_idx in pto.range(b_start, b_end, c1):
-                row_off = b_idx * cM
-                for i in pto.range(c0, cIter, c1):
-                    kOff = i * cBASEK
-                    svA = pto.slice_view(
-                        tile_view_a,
-                        source=tvA,
-                        offsets=[row_off, kOff],
-                        sizes=[cTileM, cBASEK],
-                    )
-                    svB = pto.slice_view(
-                        tile_view_b,
-                        source=tvB,
-                        offsets=[kOff, c0],
-                        sizes=[cBASEK, cTileN],
-                    )
-                    svBias = pto.slice_view(
-                        tile_view_bias,
-                        source=tvBias,
-                        offsets=[c0, c0],
-                        sizes=[c1, cTileN],
-                    )
-
-                    pto.load(svA, aMatTile)
-                    pto.load(svB, bMatTile)
-                    with pto.if_context(isBias):
-                        pto.load(svBias, biasDataTile)
-
-                    pto.record_wait_pair("LOAD", "MOV_M2L", event_id=0)
-
-                    tile.mov(aMatTile, aTile)
-                    tile.mov(bMatTile, bTile)
-                    with pto.if_context(isBias):
-                        tile.mov(biasDataTile, biasTile)
-
-                    pto.record_wait_pair("MOV_M2L", "MATMUL", event_id=0)
-                    is_i0 = s.eq(i, c0)
-
-                    def _first_iter():
-                        pto.cond(
-                            isBias,
-                            lambda: tile.matmul_bias(aTile, bTile, biasTile, cTile),
-                            lambda: tile.matmul(aTile, bTile, cTile),
-                        )
-
-                    pto.cond(
-                        is_i0,
-                        _first_iter,
-                        lambda: tile.matmul_acc(cTile, aTile, bTile, cTile),
-                    )
-                    pto.record_wait_pair("MATMUL", "LOAD", event_id=0)
-
-                pto.record_wait_pair("MATMUL", "STORE_ACC", event_id=0)
-                svOut = pto.slice_view(
-                    tile_view_out,
-                    source=tvOut,
-                    offsets=[row_off, c0],
-                    sizes=[cTileM, cTileN],
+        for b_idx in pto.range(b_start, b_end, c1):
+            row_off = b_idx * cM
+            for i in pto.range(c0, cIter, c1):
+                kOff = i * cBASEK
+                svA = pto.slice_view(
+                    tile_view_a,
+                    source=tvA,
+                    offsets=[row_off, kOff],
+                    sizes=[cTileM, cBASEK],
                 )
-                pto.store(cTile, svOut)
-                pto.record_wait_pair("STORE_ACC", "MATMUL", event_id=0)
+                svB = pto.slice_view(
+                    tile_view_b,
+                    source=tvB,
+                    offsets=[kOff, c0],
+                    sizes=[cBASEK, cTileN],
+                )
+                svBias = pto.slice_view(
+                    tile_view_bias,
+                    source=tvBias,
+                    offsets=[c0, c0],
+                    sizes=[c1, cTileN],
+                )
 
-    return RunTMATMULSplitK
+                pto.load(svA, aMatTile)
+                pto.load(svB, bMatTile)
+                with pto.if_context(isBias):
+                    pto.load(svBias, biasDataTile)
+
+                pto.record_wait_pair("LOAD", "MOV_M2L", event_id=0)
+
+                tile.mov(aMatTile, aTile)
+                tile.mov(bMatTile, bTile)
+                with pto.if_context(isBias):
+                    tile.mov(biasDataTile, biasTile)
+
+                pto.record_wait_pair("MOV_M2L", "MATMUL", event_id=0)
+                is_i0 = s.eq(i, c0)
+
+                def _first_iter():
+                    pto.cond(
+                        isBias,
+                        lambda: tile.matmul_bias(aTile, bTile, biasTile, cTile),
+                        lambda: tile.matmul(aTile, bTile, cTile),
+                    )
+
+                pto.cond(
+                    is_i0,
+                    _first_iter,
+                    lambda: tile.matmul_acc(cTile, aTile, bTile, cTile),
+                )
+                pto.record_wait_pair("MATMUL", "LOAD", event_id=0)
+
+            pto.record_wait_pair("MATMUL", "STORE_ACC", event_id=0)
+            svOut = pto.slice_view(
+                tile_view_out,
+                source=tvOut,
+                offsets=[row_off, c0],
+                sizes=[cTileM, cTileN],
+            )
+            pto.store(cTile, svOut)
+            pto.record_wait_pair("STORE_ACC", "MATMUL", event_id=0)
+
+
+def build_pythonic():
+    return to_ir_module(meta_data=meta_data)(RunTMATMULSplitK)
 
 
 def build_verbose(

--- a/tests/frontend/test_sub_ir.py
+++ b/tests/frontend/test_sub_ir.py
@@ -1,0 +1,86 @@
+from ptodsl import to_ir_module
+from ptodsl import pto, tile
+from ptodsl import scalar as s
+
+const = s.const
+
+
+def meta_data():
+    dtype = pto.float32
+    index_dtype = pto.int32
+    ptr_type = pto.PtrType(dtype)
+    tensor_type = pto.TensorType(rank=2, dtype=dtype)
+    subtensor_type = pto.SubTensorType(shape=[32, 32], dtype=dtype)
+    tile_cfg = pto.TileBufConfig()
+    tile_type = pto.TileBufType(
+        shape=[32, 32],
+        valid_shape=[-1, -1],
+        dtype=dtype,
+        memory_space="VEC",
+        config=tile_cfg,
+    )
+    return {
+        "ptr_type": ptr_type,
+        "index_dtype": index_dtype,
+        "tensor_type": tensor_type,
+        "subtensor_type": subtensor_type,
+        "tile_type": tile_type,
+    }
+
+
+def vec_sub_2d_static(
+    arg0: "ptr_type",
+    arg1: "ptr_type",
+    arg2: "ptr_type",
+    arg_vrow_i32: "index_dtype",
+    arg_vcol_i32: "index_dtype",
+) -> None:
+    c0 = const(0)
+    c1 = const(1)
+    c32 = const(32)
+    c1280 = const(1280)
+
+    cid = pto.get_block_idx()
+    sub_bid = pto.get_subblock_idx()
+    sub_bnum = pto.get_subblock_num()
+    cidmul = cid * sub_bnum
+    vid = cidmul + sub_bid
+
+    v_row_idx = s.index_cast(arg_vrow_i32)
+    v_col_idx = s.index_cast(arg_vcol_i32)
+
+    tv0 = pto.as_tensor(tensor_type, ptr=arg0, shape=[c1280, c32], strides=[c32, c1])
+    tv1 = pto.as_tensor(tensor_type, ptr=arg1, shape=[c1280, c32], strides=[c32, c1])
+    tv2 = pto.as_tensor(tensor_type, ptr=arg2, shape=[c1280, c32], strides=[c32, c1])
+
+    vid_idx = s.index_cast(vid)
+    offset_row = vid_idx * c32
+    sv0 = pto.slice_view(
+        subtensor_type, source=tv0, offsets=[offset_row, c0], sizes=[c32, c32]
+    )
+    sv1 = pto.slice_view(
+        subtensor_type, source=tv1, offsets=[offset_row, c0], sizes=[c32, c32]
+    )
+    sv2 = pto.slice_view(
+        subtensor_type, source=tv2, offsets=[offset_row, c0], sizes=[c32, c32]
+    )
+
+    with pto.vector_section():
+        tb0 = pto.alloc_tile(tile_type, valid_row=v_row_idx, valid_col=v_col_idx)
+        tb1 = pto.alloc_tile(tile_type, valid_row=v_row_idx, valid_col=v_col_idx)
+        tb2 = pto.alloc_tile(tile_type, valid_row=v_row_idx, valid_col=v_col_idx)
+
+        pto.load(sv0, tb0)
+        pto.load(sv1, tb1)
+        tile.sub(tb0, tb1, tb2)
+        pto.store(tb2, sv2)
+
+
+def test_ir_generation():
+    ir_module = to_ir_module(meta_data=meta_data)(vec_sub_2d_static)
+    ir_text = str(ir_module)
+    assert "vec_sub_2d_static" in ir_text
+    assert "pto.section.vector" in ir_text
+    assert "pto.tload" in ir_text
+    assert "pto.tsub" in ir_text
+    assert "pto.tstore" in ir_text

--- a/tests/frontend/tooling.py
+++ b/tests/frontend/tooling.py
@@ -1,0 +1,82 @@
+"""Helpers for invoking ptoas and bisheng from tests."""
+
+import os
+import shutil
+import subprocess
+
+# ---------------------------------------------------------------------------
+# Tool availability (evaluated once at import time)
+# ---------------------------------------------------------------------------
+
+_PTOAS_BIN = shutil.which("ptoas")
+_BISHENG_BIN = shutil.which("bisheng")
+_PTO_LIB_PATH = os.environ.get("PTO_LIB_PATH", "/sources/pto-isa")
+
+
+def ptoas_available():
+    """``True`` when the ``ptoas`` CLI is on ``PATH``."""
+    return _PTOAS_BIN is not None
+
+
+def bisheng_available():
+    """``True`` when ``bisheng`` is on ``PATH`` and PTO_LIB_PATH/include exists."""
+    return _BISHENG_BIN is not None and os.path.isdir(
+        os.path.join(_PTO_LIB_PATH, "include")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Runner helpers
+# ---------------------------------------------------------------------------
+
+
+def run_ptoas(pto_path, cpp_path, *, enable_insert_sync=True):
+    """Run ``ptoas`` to assemble *pto_path* → *cpp_path*.
+
+    Raises :class:`subprocess.CalledProcessError` on failure.
+    """
+    cmd = ["ptoas"]
+    if enable_insert_sync:
+        cmd.append("--enable-insert-sync")
+    cmd += [str(pto_path), "-o", str(cpp_path)]
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+
+def run_bisheng(caller_cpp, output_so, *, npu_arch="dav-2201", cwd=None):
+    """Run ``bisheng`` to compile *caller_cpp* → *output_so*.
+
+    Raises :class:`subprocess.CalledProcessError` on failure.
+    """
+    pto_isa = os.environ.get("PTO_LIB_PATH", "/sources/pto-isa")
+    cmd = [
+        "bisheng",
+        f"-I{pto_isa}/include",
+        "-fPIC",
+        "-shared",
+        "-D_FORTIFY_SOURCE=2",
+        "-O2",
+        "-std=c++17",
+        "-Wno-macro-redefined",
+        "-Wno-ignored-attributes",
+        "-fstack-protector-strong",
+        "-xcce",
+        "-Xhost-start",
+        "-Xhost-end",
+        "-mllvm",
+        "-cce-aicore-stack-size=0x8000",
+        "-mllvm",
+        "-cce-aicore-function-stack-size=0x8000",
+        "-mllvm",
+        "-cce-aicore-record-overflow=true",
+        "-mllvm",
+        "-cce-aicore-addr-transform",
+        "-mllvm",
+        "-cce-aicore-dcci-insert-for-scalar=false",
+        f"--npu-arch={npu_arch}",
+        "-DMEMORY_BASE",
+        "-std=gnu++17",
+        str(caller_cpp),
+        "-o",
+        str(output_so),
+    ]
+    subprocess.run(cmd, check=True, capture_output=True, text=True, cwd=cwd)


### PR DESCRIPTION
Frontend tests now verify that DSL-generated pto IR can be assembled by ptoas and compiled end-to-end through bisheng. 

`test_compile.py` Auto-discovers DSL kernels from sibling `test_*_ir.py` modules and parametrizes ptoas assembly + bisheng compilation tests. Adding a new `test_<op>_ir.py` with a top-level `meta_data()` and kernel function is all that's needed.