### PR TITLE
feat: remove `entry=True` arg to decorator `pto.func`

### DIFF
--- a/examples/aot/tpushpop/mix-kernel_mlir/kernels/bidi_builder.py
+++ b/examples/aot/tpushpop/mix-kernel_mlir/kernels/bidi_builder.py
@@ -117,7 +117,7 @@ def module():
         pto.tpush_to_aic(doubled_tile, 0)
         pto.tfree_from_aic(0)
 
-    @pto.func(entry=True)
+    @pto.func
     def call_both(
         ffts_addr: "ffts_ty", gm_slot_buffer: "ptr_ty", gm_x: "ptr_ty", gm_y: "ptr_ty"
     ) -> None:

--- a/examples/aot/tpushpop/mix-kernel_mlir/kernels/c2v_add_builder.py
+++ b/examples/aot/tpushpop/mix-kernel_mlir/kernels/c2v_add_builder.py
@@ -104,7 +104,7 @@ def module():
         pto.store(doubled_tile, gm_y_tile_view)
         pto.tfree_from_aic(0)
 
-    @pto.func(entry=True)
+    @pto.func
     def call_both(
         ffts_addr: "ffts_ty", gm_slot_buffer: "ptr_ty", gm_x: "ptr_ty", gm_y: "ptr_ty"
     ) -> None:

--- a/examples/aot/tpushpop/mix-kernel_mlir/kernels/c2v_builder.py
+++ b/examples/aot/tpushpop/mix-kernel_mlir/kernels/c2v_builder.py
@@ -99,7 +99,7 @@ def module():
         pto.store(pto.tpop_from_aic(recv_ty, 0), gm_y_tile_view)
         pto.tfree_from_aic(0)
 
-    @pto.func(entry=True)
+    @pto.func
     def call_both(
         ffts_addr: "ffts_ty", gm_slot_buffer: "ptr_ty", gm_x: "ptr_ty", gm_y: "ptr_ty"
     ) -> None:

--- a/examples/aot/tpushpop/mix-kernel_mlir/kernels/v2c_builder.py
+++ b/examples/aot/tpushpop/mix-kernel_mlir/kernels/v2c_builder.py
@@ -93,7 +93,7 @@ def module():
         pto.load(gm_x_tile_view, send_tile)
         pto.tpush_to_aic(send_tile, 0)
 
-    @pto.func(entry=True)
+    @pto.func
     def call_both(
         ffts_addr: "ffts_ty", gm_slot_buffer: "ptr_ty", gm_x: "ptr_ty", gm_y: "ptr_ty"
     ) -> None:

--- a/ptodsl/compiler/ir.py
+++ b/ptodsl/compiler/ir.py
@@ -111,11 +111,13 @@ def _define(module, ctx, meta_map, fn, *, name=None, entry=False, kernel=None):
     return FuncRef(fn_name)
 
 
-def ir_func(*, name=None, entry=False, kernel=None):
+def ir_func(fn=None, *, name=None, kernel=None):
+    entry = kernel is None
+
     def decorator(fn):
         if _CURRENT is None:
             raise RuntimeError(
-                "`pto.func(...)` can only be used inside `@to_ir_module(..., module=True)`."
+                "`pto.func` can only be used inside `@to_ir_module(..., module=True)`."
             )
         return _define(
             _CURRENT["module"],
@@ -126,6 +128,9 @@ def ir_func(*, name=None, entry=False, kernel=None):
             entry=entry,
             kernel=kernel,
         )
+
+    if fn is not None:
+        return decorator(fn)
 
     return decorator
 

--- a/tests/frontend/test_multifunc_ir.py
+++ b/tests/frontend/test_multifunc_ir.py
@@ -32,7 +32,7 @@ def multi_kernel_module():
     def worker(arg0: "ptr_ty") -> None:
         pass
 
-    @pto.func(entry=True)
+    @pto.func
     def entry(arg0: "ptr_ty") -> None:
         pto.call(worker, arg0)
 


### PR DESCRIPTION
Based on comment in #98.

Now `@pto.func` decorator defaults to `entry=True` when used without any arguments