### PR TITLE
Optimize sinkhorn performance

### DIFF
--- a/examples/aot/sinkhorn_demo/README.md
+++ b/examples/aot/sinkhorn_demo/README.md
@@ -5,7 +5,7 @@ bash ./compile.sh
 pytest ./test_sinkhorn.py -v --npu=7
 ```
 
-`./compile.sh` also builds the hand-written C++ reference under `cpp_ref/outputs/kernel_sinkhorn.so` (see `cpp_ref/compile.sh`).
+`./compile.sh` also builds the hand-written C++ references under `cpp_ref/outputs/kernel_sinkhorn.so` (BATCH=8) and `cpp_ref/outputs/kernel_sinkhorn_v2.so` (interleaved fast path), see `cpp_ref/compile.sh`.
 
 ## Bandwidth (large shapes)
 
@@ -15,7 +15,9 @@ Forward pass only; numbers are **median effective GB/s** (decimal 10^9 bytes per
 |--------|--------|
 | **Batched** | `sinkhorn_batch8_builder.py` → `ptoas --enable-insert-sync` (PTODSL) |
 | **Naive** | `sinkhorn_k4_builder.py` → `ptoas --enable-insert-sync` (PTODSL) |
-| **C++ ref** | `cpp_ref/kernel_sinkhorn.cpp` → `cpp_ref/compile.sh` (bisheng, manual sync) |
+| **v2 (PTODSL)** | `sinkhorn_v2_builder.py` → `ptoas --enable-insert-sync` (PTODSL; large-`N` path uses a 32-matrix stack like batched, with `eps` like the demo ref) |
+| **C++ ref (v1)** | `cpp_ref/kernel_sinkhorn.cpp` → `cpp_ref/compile.sh` (bisheng, BATCH=8) |
+| **C++ ref (v2)** | `cpp_ref/kernel_sinkhorn_v2.cpp` → `cpp_ref/compile.sh` (bisheng, interleaved `TCOLSUM` fast path) |
 
 Run locally (pick a free NPU, e.g. `npu-smi info`). After `./compile.sh`, the C++ `.so` is already in `cpp_ref/outputs/`. Otherwise:
 
@@ -25,11 +27,11 @@ python3 bench_sinkhorn_bandwidth.py --npu 0
 # optional: --shapes 65536,262144 --build-cpp --warmup 8 --iters 24 --no-cpp
 ```
 
-Sample run on **Ascend 910B2**, `repeat=10`, `warmup=8`, `iters=24`, C++ ref from `cpp_ref/` (batched kernel uses a static unrolled tail, ``repeat=10`` in `sinkhorn_batch8_builder.py`):
+Sample run on **Ascend 910B2**, `repeat=10`, `warmup=8`, `iters=24`, from `cpp_ref/` (batched / naive / PTODSL v2 use a static unrolled tail, ``repeat=10`` in the builders). Benchmark: `python3 bench_sinkhorn_bandwidth.py --npu …`.
 
-| Shape (matrices) | Batched GB/s | Naive GB/s | C++ ref GB/s | Batched / naive | Batched / C++ |
-|------------------|-------------:|-----------:|-------------:|----------------:|--------------:|
-| (1, 65536, 4, 4) — 65536 matrices | 1.511 | 1.161 | 1.431 | 1.30 | 1.06 |
-| (1, 262144, 4, 4) — 262144 matrices | 1.594 | 1.184 | 1.507 | 1.35 | 1.06 |
+| Shape (matrices) | Batched GB/s | Naive GB/s | v2 Py GB/s | C++ v1 GB/s | C++ v2 GB/s | Batched / naive | v2 Py / C++ v2 |
+|------------------|-------------:|-----------:|------------:|------------:|------------:|----------------:|---------------:|
+| (1, 65536, 4, 4) — 65536 matrices | 1.515 | 1.162 | 1.712 | 1.430 | 5.934 | 1.30 | 0.29 |
+| (1, 262144, 4, 4) — 262144 matrices | 1.596 | 1.183 | 1.794 | 1.502 | 6.997 | 1.35 | 0.26 |
 
-PTODSL batched matches the C++ reference algorithm (BATCH=8 stack); effective GB/s can differ slightly from the hand kernel (auto-inserted sync, codegen). Absolute GB/s varies by chip and load.
+PTODSL **batched** matches the C++ v1 (BATCH=8) algorithm. **v2 (PTODSL)** is a larger stack (32 matrices per chunk) with the same `eps` pattern as batched on the large-`N` path so it tracks `sinkhorn_normalize_ref` in tests; the hand **C++ v2** kernel uses interleaved column reduction and different sync/pipelining, so effective GB/s is not directly comparable column-for-column. Absolute GB/s varies by chip and load.

--- a/examples/aot/sinkhorn_demo/README.md
+++ b/examples/aot/sinkhorn_demo/README.md
@@ -4,3 +4,23 @@
 bash ./compile.sh
 pytest ./test_sinkhorn.py -v --npu=7
 ```
+
+## Bandwidth (large shapes)
+
+Forward pass only; numbers are **median effective GB/s** (decimal 10^9 bytes per second) counting one read plus one write of all 4×4 fp16 matrices—same convention as `pto-kernels-sinkhorn-demo/examples/jit_cpp/fast_hadamard/bench_common.py`. **Batched** is `sinkhorn_batch8_builder.py` (stack load); **naive** is `sinkhorn_k4_builder.py`.
+
+Run locally (pick a free NPU, e.g. `npu-smi info`):
+
+```bash
+python3 bench_sinkhorn_bandwidth.py --npu 0
+# optional: --shapes 65536,262144,1048576 --warmup 8 --iters 24
+```
+
+Sample run on **Ascend 910B2**, `repeat=10`, `warmup=8`, `iters=24`:
+
+| Shape (matrices) | Batched GB/s | Naive GB/s | Batched / naive |
+|------------------|-------------:|-----------:|----------------:|
+| (1, 65536, 4, 4) — 65536 matrices | 1.511 | 1.162 | 1.30 |
+| (1, 262144, 4, 4) — 262144 matrices | 1.597 | 1.185 | 1.35 |
+
+Absolute GB/s depends on chip, driver, and load; the ratio is the usual takeaway for this demo.

--- a/examples/aot/sinkhorn_demo/README.md
+++ b/examples/aot/sinkhorn_demo/README.md
@@ -5,22 +5,31 @@ bash ./compile.sh
 pytest ./test_sinkhorn.py -v --npu=7
 ```
 
+`./compile.sh` also builds the hand-written C++ reference under `cpp_ref/outputs/kernel_sinkhorn.so` (see `cpp_ref/compile.sh`).
+
 ## Bandwidth (large shapes)
 
-Forward pass only; numbers are **median effective GB/s** (decimal 10^9 bytes per second) counting one read plus one write of all 4×4 fp16 matrices—same convention as `pto-kernels-sinkhorn-demo/examples/jit_cpp/fast_hadamard/bench_common.py`. **Batched** is `sinkhorn_batch8_builder.py` (stack load); **naive** is `sinkhorn_k4_builder.py`.
+Forward pass only; numbers are **median effective GB/s** (decimal 10^9 bytes per second) counting one read plus one write of all 4×4 fp16 matrices—same convention as `pto-kernels-sinkhorn-demo/examples/jit_cpp/fast_hadamard/bench_common.py`.
 
-Run locally (pick a free NPU, e.g. `npu-smi info`):
+| Kernel | Source |
+|--------|--------|
+| **Batched** | `sinkhorn_batch8_builder.py` → `ptoas --enable-insert-sync` (PTODSL) |
+| **Naive** | `sinkhorn_k4_builder.py` → `ptoas --enable-insert-sync` (PTODSL) |
+| **C++ ref** | `cpp_ref/kernel_sinkhorn.cpp` → `cpp_ref/compile.sh` (bisheng, manual sync) |
+
+Run locally (pick a free NPU, e.g. `npu-smi info`). After `./compile.sh`, the C++ `.so` is already in `cpp_ref/outputs/`. Otherwise:
 
 ```bash
+bash cpp_ref/compile.sh
 python3 bench_sinkhorn_bandwidth.py --npu 0
-# optional: --shapes 65536,262144,1048576 --warmup 8 --iters 24
+# optional: --shapes 65536,262144 --build-cpp --warmup 8 --iters 24 --no-cpp
 ```
 
-Sample run on **Ascend 910B2**, `repeat=10`, `warmup=8`, `iters=24`:
+Sample run on **Ascend 910B2**, `repeat=10`, `warmup=8`, `iters=24`, C++ ref from `cpp_ref/`:
 
-| Shape (matrices) | Batched GB/s | Naive GB/s | Batched / naive |
-|------------------|-------------:|-----------:|----------------:|
-| (1, 65536, 4, 4) — 65536 matrices | 1.511 | 1.162 | 1.30 |
-| (1, 262144, 4, 4) — 262144 matrices | 1.597 | 1.185 | 1.35 |
+| Shape (matrices) | Batched GB/s | Naive GB/s | C++ ref GB/s | Batched / naive | Batched / C++ |
+|------------------|-------------:|-----------:|-------------:|----------------:|--------------:|
+| (1, 65536, 4, 4) — 65536 matrices | 1.508 | 1.162 | 1.434 | 1.30 | 1.05 |
+| (1, 262144, 4, 4) — 262144 matrices | 1.593 | 1.185 | 1.495 | 1.34 | 1.07 |
 
-Absolute GB/s depends on chip, driver, and load; the ratio is the usual takeaway for this demo.
+PTODSL batched matches the C++ reference algorithm (BATCH=8 stack); effective GB/s can differ slightly from the hand kernel (auto-inserted sync, codegen). Absolute GB/s varies by chip and load.

--- a/examples/aot/sinkhorn_demo/README.md
+++ b/examples/aot/sinkhorn_demo/README.md
@@ -25,11 +25,11 @@ python3 bench_sinkhorn_bandwidth.py --npu 0
 # optional: --shapes 65536,262144 --build-cpp --warmup 8 --iters 24 --no-cpp
 ```
 
-Sample run on **Ascend 910B2**, `repeat=10`, `warmup=8`, `iters=24`, C++ ref from `cpp_ref/`:
+Sample run on **Ascend 910B2**, `repeat=10`, `warmup=8`, `iters=24`, C++ ref from `cpp_ref/` (batched kernel uses a static unrolled tail, ``repeat=10`` in `sinkhorn_batch8_builder.py`):
 
 | Shape (matrices) | Batched GB/s | Naive GB/s | C++ ref GB/s | Batched / naive | Batched / C++ |
 |------------------|-------------:|-----------:|-------------:|----------------:|--------------:|
-| (1, 65536, 4, 4) — 65536 matrices | 1.508 | 1.162 | 1.434 | 1.30 | 1.05 |
-| (1, 262144, 4, 4) — 262144 matrices | 1.593 | 1.185 | 1.495 | 1.34 | 1.07 |
+| (1, 65536, 4, 4) — 65536 matrices | 1.511 | 1.161 | 1.431 | 1.30 | 1.06 |
+| (1, 262144, 4, 4) — 262144 matrices | 1.594 | 1.184 | 1.507 | 1.35 | 1.06 |
 
 PTODSL batched matches the C++ reference algorithm (BATCH=8 stack); effective GB/s can differ slightly from the hand kernel (auto-inserted sync, codegen). Absolute GB/s varies by chip and load.

--- a/examples/aot/sinkhorn_demo/bench_sinkhorn_bandwidth.py
+++ b/examples/aot/sinkhorn_demo/bench_sinkhorn_bandwidth.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
 """
-Median effective memory bandwidth (GB/s) for Sinkhorn forward: batched vs naive.
+Median effective memory bandwidth (GB/s) for Sinkhorn forward:
 
-Uses the same byte accounting and timing style as ``jit_util_sinkhorn.bench_sinkhorn_forward_gbs``
-(read fp16 input + write fp16 output per launch). Run after ``./compile.sh``.
+- **Batched** / **naive**: PTODSL builders from this directory (after ``./compile.sh``).
+- **C++ ref**: hand-written ``cpp_ref/kernel_sinkhorn.cpp`` (same ``call_sinkhorn`` ABI).
+  Use ``--build-cpp`` to run ``cpp_ref/compile.sh`` if the ``.so`` is missing.
+
+Uses ``jit_util_sinkhorn.bench_sinkhorn_forward_gbs`` (read fp16 + write fp16 per launch).
 """
 
 from __future__ import annotations
 
 import argparse
+import subprocess
 import sys
 from pathlib import Path
 
@@ -20,7 +24,33 @@ if str(_demo_dir) not in sys.path:
 
 import torch_npu  # noqa: E402, F401
 
-from jit_util_sinkhorn import bench_sinkhorn_forward_gbs  # noqa: E402
+from jit_util_sinkhorn import bench_sinkhorn_forward_gbs, load_sinkhorn_host_lib  # noqa: E402
+
+
+def cpp_ref_dir() -> Path:
+    return _demo_dir / "cpp_ref"
+
+
+def default_cpp_kernel_so() -> Path:
+    return cpp_ref_dir() / "outputs" / "kernel_sinkhorn.so"
+
+
+def default_cpp_kernel_src() -> Path:
+    return cpp_ref_dir() / "kernel_sinkhorn.cpp"
+
+
+def build_cpp_reference_kernel() -> Path:
+    """Run ``cpp_ref/compile.sh`` (bisheng manual-sync batched kernel)."""
+    script = cpp_ref_dir() / "compile.sh"
+    if not script.is_file():
+        raise FileNotFoundError(f"Missing {script}")
+    if not default_cpp_kernel_src().is_file():
+        raise FileNotFoundError(f"C++ kernel source not found: {default_cpp_kernel_src()}")
+    subprocess.run(["bash", str(script)], check=True, cwd=str(cpp_ref_dir()))
+    out = default_cpp_kernel_so()
+    if not out.is_file():
+        raise FileNotFoundError(f"Expected {out} after compile")
+    return out
 
 
 def _parse_npu(s: str) -> str:
@@ -47,6 +77,22 @@ def main() -> None:
         default="65536,262144",
         help="Comma-separated n1 values for shape (1, n1, 4, 4).",
     )
+    p.add_argument(
+        "--cpp-so",
+        type=Path,
+        default=None,
+        help="Path to C++ reference call_sinkhorn .so (default: cpp_ref/outputs/kernel_sinkhorn.so).",
+    )
+    p.add_argument(
+        "--build-cpp",
+        action="store_true",
+        help="Run cpp_ref/compile.sh when --cpp-so is missing.",
+    )
+    p.add_argument(
+        "--no-cpp",
+        action="store_true",
+        help="Do not benchmark the hand-written C++ kernel.",
+    )
     args = p.parse_args()
 
     device = _parse_npu(args.npu)
@@ -54,22 +100,73 @@ def main() -> None:
 
     n1_list = [int(x.strip()) for x in args.shapes.split(",") if x.strip()]
 
+    cpp_so: Path | None = None
+    cpp_lib = None
+    if not args.no_cpp:
+        cpp_so = args.cpp_so or default_cpp_kernel_so()
+        if not cpp_so.is_file() and args.build_cpp:
+            build_cpp_reference_kernel()
+            cpp_so = args.cpp_so or default_cpp_kernel_so()
+        if cpp_so.is_file():
+            cpp_lib = load_sinkhorn_host_lib(cpp_so)
+        elif args.cpp_so is not None:
+            sys.stderr.write(f"error: C++ .so not found: {cpp_so}\n")
+            sys.exit(1)
+        else:
+            sys.stderr.write(
+                f"note: skipping C++ reference (no {cpp_so}). "
+                "Run ./compile.sh or: python3 bench_sinkhorn_bandwidth.py --build-cpp\n"
+            )
+
     print(f"device={device} warmup={args.warmup} iters={args.iters} repeat={args.repeat}")
-    print("shape (matrices) | batched GB/s | naive GB/s | ratio")
-    print("---|---:|---:|---:")
+    if cpp_lib is not None:
+        print(
+            "shape (matrices) | batched GB/s | naive GB/s | C++ ref GB/s | batched/naive | batched/C++"
+        )
+        print("---|---:|---:|---:|---:|---:")
+    else:
+        print("shape (matrices) | batched GB/s | naive GB/s | batched/naive")
+        print("---|---:|---:|---:")
 
     for n1 in n1_list:
         torch.manual_seed(1)
         x = torch.randn((1, n1, 4, 4), dtype=torch.float16, device=device)
         bw_b = bench_sinkhorn_forward_gbs(
-            x, args.repeat, args.eps, impl="batched", warmup=args.warmup, iters=args.iters
+            x,
+            args.repeat,
+            args.eps,
+            impl="batched",
+            warmup=args.warmup,
+            iters=args.iters,
         )
         bw_n = bench_sinkhorn_forward_gbs(
-            x, args.repeat, args.eps, impl="naive", warmup=args.warmup, iters=args.iters
+            x,
+            args.repeat,
+            args.eps,
+            impl="naive",
+            warmup=args.warmup,
+            iters=args.iters,
         )
-        ratio = bw_b / bw_n if bw_n > 0 else float("nan")
+        ratio_bn = bw_b / bw_n if bw_n > 0 else float("nan")
         nmat = n1
-        print(f"(1, {n1}, 4, 4) ({nmat} matrices) | {bw_b:.3f} | {bw_n:.3f} | {ratio:.3f}")
+        if cpp_lib is not None:
+            bw_c = bench_sinkhorn_forward_gbs(
+                x,
+                args.repeat,
+                args.eps,
+                lib=cpp_lib,
+                warmup=args.warmup,
+                iters=args.iters,
+            )
+            ratio_bc = bw_b / bw_c if bw_c > 0 else float("nan")
+            print(
+                f"(1, {n1}, 4, 4) ({nmat} matrices) | {bw_b:.3f} | {bw_n:.3f} | {bw_c:.3f} | "
+                f"{ratio_bn:.3f} | {ratio_bc:.3f}"
+            )
+        else:
+            print(
+                f"(1, {n1}, 4, 4) ({nmat} matrices) | {bw_b:.3f} | {bw_n:.3f} | {ratio_bn:.3f}"
+            )
 
 
 if __name__ == "__main__":

--- a/examples/aot/sinkhorn_demo/bench_sinkhorn_bandwidth.py
+++ b/examples/aot/sinkhorn_demo/bench_sinkhorn_bandwidth.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+Median effective memory bandwidth (GB/s) for Sinkhorn forward: batched vs naive.
+
+Uses the same byte accounting and timing style as ``jit_util_sinkhorn.bench_sinkhorn_forward_gbs``
+(read fp16 input + write fp16 output per launch). Run after ``./compile.sh``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+
+_demo_dir = Path(__file__).resolve().parent
+if str(_demo_dir) not in sys.path:
+    sys.path.insert(0, str(_demo_dir))
+
+import torch_npu  # noqa: E402, F401
+
+from jit_util_sinkhorn import bench_sinkhorn_forward_gbs  # noqa: E402
+
+
+def _parse_npu(s: str) -> str:
+    t = s.strip().strip('"').strip("'")
+    if t.lower().startswith("npu:"):
+        return f"npu:{int(t.split(':', 1)[1])}"
+    return f"npu:{int(t)}"
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--npu",
+        default="0",
+        help="NPU index or npu:N (default: 0).",
+    )
+    p.add_argument("--warmup", type=int, default=8)
+    p.add_argument("--iters", type=int, default=24)
+    p.add_argument("--repeat", type=int, default=10, help="Sinkhorn repeat count.")
+    p.add_argument("--eps", type=float, default=1e-6)
+    p.add_argument(
+        "--shapes",
+        type=str,
+        default="65536,262144",
+        help="Comma-separated n1 values for shape (1, n1, 4, 4).",
+    )
+    args = p.parse_args()
+
+    device = _parse_npu(args.npu)
+    torch.npu.set_device(device)
+
+    n1_list = [int(x.strip()) for x in args.shapes.split(",") if x.strip()]
+
+    print(f"device={device} warmup={args.warmup} iters={args.iters} repeat={args.repeat}")
+    print("shape (matrices) | batched GB/s | naive GB/s | ratio")
+    print("---|---:|---:|---:")
+
+    for n1 in n1_list:
+        torch.manual_seed(1)
+        x = torch.randn((1, n1, 4, 4), dtype=torch.float16, device=device)
+        bw_b = bench_sinkhorn_forward_gbs(
+            x, args.repeat, args.eps, impl="batched", warmup=args.warmup, iters=args.iters
+        )
+        bw_n = bench_sinkhorn_forward_gbs(
+            x, args.repeat, args.eps, impl="naive", warmup=args.warmup, iters=args.iters
+        )
+        ratio = bw_b / bw_n if bw_n > 0 else float("nan")
+        nmat = n1
+        print(f"(1, {n1}, 4, 4) ({nmat} matrices) | {bw_b:.3f} | {bw_n:.3f} | {ratio:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/aot/sinkhorn_demo/bench_sinkhorn_bandwidth.py
+++ b/examples/aot/sinkhorn_demo/bench_sinkhorn_bandwidth.py
@@ -2,9 +2,9 @@
 """
 Median effective memory bandwidth (GB/s) for Sinkhorn forward:
 
-- **Batched** / **naive**: PTODSL builders from this directory (after ``./compile.sh``).
-- **C++ ref**: hand-written ``cpp_ref/kernel_sinkhorn.cpp`` (same ``call_sinkhorn`` ABI).
-  Use ``--build-cpp`` to run ``cpp_ref/compile.sh`` if the ``.so`` is missing.
+- **Batched** / **naive** / **v2 (PTODSL)**: builders from this directory (after ``./compile.sh``).
+- **C++ v1 / v2**: ``cpp_ref/outputs/kernel_sinkhorn*.so`` (same ``call_sinkhorn`` ABI).
+  Use ``--build-cpp`` to run ``cpp_ref/compile.sh`` if a ``.so`` is missing.
 
 Uses ``jit_util_sinkhorn.bench_sinkhorn_forward_gbs`` (read fp16 + write fp16 per launch).
 """
@@ -33,6 +33,10 @@ def cpp_ref_dir() -> Path:
 
 def default_cpp_kernel_so() -> Path:
     return cpp_ref_dir() / "outputs" / "kernel_sinkhorn.so"
+
+
+def default_cpp_v2_kernel_so() -> Path:
+    return cpp_ref_dir() / "outputs" / "kernel_sinkhorn_v2.so"
 
 
 def default_cpp_kernel_src() -> Path:
@@ -102,6 +106,7 @@ def main() -> None:
 
     cpp_so: Path | None = None
     cpp_lib = None
+    cpp_v2_lib = None
     if not args.no_cpp:
         cpp_so = args.cpp_so or default_cpp_kernel_so()
         if not cpp_so.is_file() and args.build_cpp:
@@ -117,16 +122,25 @@ def main() -> None:
                 f"note: skipping C++ reference (no {cpp_so}). "
                 "Run ./compile.sh or: python3 bench_sinkhorn_bandwidth.py --build-cpp\n"
             )
+        cpp_v2_so = default_cpp_v2_kernel_so()
+        if cpp_v2_so.is_file():
+            cpp_v2_lib = load_sinkhorn_host_lib(cpp_v2_so)
 
     print(f"device={device} warmup={args.warmup} iters={args.iters} repeat={args.repeat}")
     if cpp_lib is not None:
-        print(
-            "shape (matrices) | batched GB/s | naive GB/s | C++ ref GB/s | batched/naive | batched/C++"
-        )
-        print("---|---:|---:|---:|---:|---:")
+        if cpp_v2_lib is not None:
+            print(
+                "shape (matrices) | batched | naive | v2 Py | C++ v1 | C++ v2 | batched/naive | v2 Py/C++ v2"
+            )
+            print("---|---:|---:|---:|---:|---:|---:|---:")
+        else:
+            print(
+                "shape (matrices) | batched GB/s | naive GB/s | v2 Py GB/s | C++ ref GB/s | batched/naive | batched/C++"
+            )
+            print("---|---:|---:|---:|---:|---:|---:")
     else:
-        print("shape (matrices) | batched GB/s | naive GB/s | batched/naive")
-        print("---|---:|---:|---:")
+        print("shape (matrices) | batched GB/s | naive GB/s | v2 Py GB/s | batched/naive")
+        print("---|---:|---:|---:|---:")
 
     for n1 in n1_list:
         torch.manual_seed(1)
@@ -147,6 +161,14 @@ def main() -> None:
             warmup=args.warmup,
             iters=args.iters,
         )
+        bw_v2 = bench_sinkhorn_forward_gbs(
+            x,
+            args.repeat,
+            args.eps,
+            impl="v2",
+            warmup=args.warmup,
+            iters=args.iters,
+        )
         ratio_bn = bw_b / bw_n if bw_n > 0 else float("nan")
         nmat = n1
         if cpp_lib is not None:
@@ -159,13 +181,28 @@ def main() -> None:
                 iters=args.iters,
             )
             ratio_bc = bw_b / bw_c if bw_c > 0 else float("nan")
-            print(
-                f"(1, {n1}, 4, 4) ({nmat} matrices) | {bw_b:.3f} | {bw_n:.3f} | {bw_c:.3f} | "
-                f"{ratio_bn:.3f} | {ratio_bc:.3f}"
-            )
+            if cpp_v2_lib is not None:
+                bw_cv2 = bench_sinkhorn_forward_gbs(
+                    x,
+                    args.repeat,
+                    args.eps,
+                    lib=cpp_v2_lib,
+                    warmup=args.warmup,
+                    iters=args.iters,
+                )
+                ratio_v2 = bw_v2 / bw_cv2 if bw_cv2 > 0 else float("nan")
+                print(
+                    f"(1, {n1}, 4, 4) ({nmat} matrices) | {bw_b:.3f} | {bw_n:.3f} | {bw_v2:.3f} | "
+                    f"{bw_c:.3f} | {bw_cv2:.3f} | {ratio_bn:.3f} | {ratio_v2:.3f}"
+                )
+            else:
+                print(
+                    f"(1, {n1}, 4, 4) ({nmat} matrices) | {bw_b:.3f} | {bw_n:.3f} | {bw_v2:.3f} | {bw_c:.3f} | "
+                    f"{ratio_bn:.3f} | {ratio_bc:.3f}"
+                )
         else:
             print(
-                f"(1, {n1}, 4, 4) ({nmat} matrices) | {bw_b:.3f} | {bw_n:.3f} | {ratio_bn:.3f}"
+                f"(1, {n1}, 4, 4) ({nmat} matrices) | {bw_b:.3f} | {bw_n:.3f} | {bw_v2:.3f} | {ratio_bn:.3f}"
             )
 
 

--- a/examples/aot/sinkhorn_demo/caller_sinkhorn_v2.cpp
+++ b/examples/aot/sinkhorn_demo/caller_sinkhorn_v2.cpp
@@ -1,0 +1,24 @@
+/**
+ * Host launcher for ``sinkhorn_v2_fp16`` emitted from ``sinkhorn_v2_builder.py``.
+ * Exports ``call_sinkhorn`` for ctypes / torch_npu (same ABI as ``caller_sinkhorn_k4.cpp``).
+ */
+#ifndef KERNEL_CPP
+#define KERNEL_CPP "outputs/sinkhorn_v2_generated.cpp"
+#endif
+#include KERNEL_CPP
+
+extern "C" void call_sinkhorn(
+    uint32_t cube_core_num,
+    void *stream,
+    uint8_t *input,
+    uint8_t *output,
+    uint32_t num_matrices,
+    uint32_t repeat,
+    float eps) {
+  sinkhorn_v2_fp16<<<cube_core_num * 2, nullptr, stream>>>(
+      (__gm__ half *)input,
+      (__gm__ half *)output,
+      static_cast<int32_t>(num_matrices),
+      static_cast<int32_t>(repeat),
+      eps);
+}

--- a/examples/aot/sinkhorn_demo/compile.sh
+++ b/examples/aot/sinkhorn_demo/compile.sh
@@ -18,6 +18,9 @@ ptoas --enable-insert-sync outputs/sinkhorn_batch8.pto -o outputs/sinkhorn_batch
 python3 sinkhorn_k4_builder.py > outputs/sinkhorn_k4.pto
 ptoas --enable-insert-sync outputs/sinkhorn_k4.pto -o outputs/sinkhorn_k4_generated.cpp
 
+python3 sinkhorn_v2_builder.py > outputs/sinkhorn_v2.pto
+ptoas --enable-insert-sync outputs/sinkhorn_v2.pto -o outputs/sinkhorn_v2_generated.cpp
+
 BFLAGS=(
   -fPIC -shared -xcce -DMEMORY_BASE
   -O2 -std=c++17 -Wno-ignored-attributes
@@ -35,6 +38,11 @@ bisheng "${BFLAGS[@]}" \
   caller_sinkhorn_k4.cpp \
   -o outputs/kernel_sinkhorn_naive.so
 
-echo "Built outputs/kernel_sinkhorn.so (batched) and outputs/kernel_sinkhorn_naive.so (naive)."
+bisheng "${BFLAGS[@]}" \
+  -DKERNEL_CPP=\"outputs/sinkhorn_v2_generated.cpp\" \
+  caller_sinkhorn_v2.cpp \
+  -o outputs/kernel_sinkhorn_v2.so
+
+echo "Built outputs/kernel_sinkhorn.so (batched), outputs/kernel_sinkhorn_naive.so (naive), outputs/kernel_sinkhorn_v2.so (v2)."
 
 bash cpp_ref/compile.sh

--- a/examples/aot/sinkhorn_demo/compile.sh
+++ b/examples/aot/sinkhorn_demo/compile.sh
@@ -36,3 +36,5 @@ bisheng "${BFLAGS[@]}" \
   -o outputs/kernel_sinkhorn_naive.so
 
 echo "Built outputs/kernel_sinkhorn.so (batched) and outputs/kernel_sinkhorn_naive.so (naive)."
+
+bash cpp_ref/compile.sh

--- a/examples/aot/sinkhorn_demo/compile.sh
+++ b/examples/aot/sinkhorn_demo/compile.sh
@@ -3,16 +3,36 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 mkdir -p outputs
+
+PTO_ROOT="${PTO_LIB_PATH:-}"
+if [[ -z "${PTO_ROOT}" || ! -f "${PTO_ROOT}/include/pto/pto-inst.hpp" ]]; then
+  PTO_ROOT="/workdir/pto-isa-master"
+fi
+if [[ ! -f "${PTO_ROOT}/include/pto/pto-inst.hpp" ]]; then
+  PTO_ROOT="${PTO_LIB_PATH:-/sources/pto-isa}"
+fi
+
+python3 sinkhorn_batch8_builder.py > outputs/sinkhorn_batch8.pto
+ptoas --enable-insert-sync outputs/sinkhorn_batch8.pto -o outputs/sinkhorn_batch8_generated.cpp
+
 python3 sinkhorn_k4_builder.py > outputs/sinkhorn_k4.pto
 ptoas --enable-insert-sync outputs/sinkhorn_k4.pto -o outputs/sinkhorn_k4_generated.cpp
 
-PTO_LIB_PATH="${PTO_LIB_PATH:-/sources/pto-isa}"
-bisheng \
-  -fPIC -shared -xcce -DMEMORY_BASE \
-  -O2 -std=c++17 -Wno-ignored-attributes \
-  --cce-aicore-arch=dav-c220-vec \
-  -isystem "${PTO_LIB_PATH}/include" \
+BFLAGS=(
+  -fPIC -shared -xcce -DMEMORY_BASE
+  -O2 -std=c++17 -Wno-ignored-attributes
+  --cce-aicore-arch=dav-c220-vec
+  "-I${PTO_ROOT}/include"
+)
+
+bisheng "${BFLAGS[@]}" \
+  -DKERNEL_CPP=\"outputs/sinkhorn_batch8_generated.cpp\" \
   caller_sinkhorn_k4.cpp \
   -o outputs/kernel_sinkhorn.so
 
-echo "Built outputs/kernel_sinkhorn.so"
+bisheng "${BFLAGS[@]}" \
+  -DKERNEL_CPP=\"outputs/sinkhorn_k4_generated.cpp\" \
+  caller_sinkhorn_k4.cpp \
+  -o outputs/kernel_sinkhorn_naive.so
+
+echo "Built outputs/kernel_sinkhorn.so (batched) and outputs/kernel_sinkhorn_naive.so (naive)."

--- a/examples/aot/sinkhorn_demo/cpp_ref/.gitignore
+++ b/examples/aot/sinkhorn_demo/cpp_ref/.gitignore
@@ -1,0 +1,1 @@
+outputs/

--- a/examples/aot/sinkhorn_demo/cpp_ref/compile.sh
+++ b/examples/aot/sinkhorn_demo/cpp_ref/compile.sh
@@ -22,4 +22,12 @@ bisheng \
   kernel_sinkhorn.cpp \
   -o outputs/kernel_sinkhorn.so
 
-echo "Built $(pwd)/outputs/kernel_sinkhorn.so (C++ reference)"
+bisheng \
+  -fPIC -shared -xcce -DMEMORY_BASE \
+  -O2 -std=c++17 -Wno-ignored-attributes \
+  --cce-aicore-arch=dav-c220-vec \
+  "-I${PTO_ROOT}/include" \
+  kernel_sinkhorn_v2.cpp \
+  -o outputs/kernel_sinkhorn_v2.so
+
+echo "Built $(pwd)/outputs/kernel_sinkhorn.so (C++ BATCH=8) and $(pwd)/outputs/kernel_sinkhorn_v2.so (C++ v2)"

--- a/examples/aot/sinkhorn_demo/cpp_ref/compile.sh
+++ b/examples/aot/sinkhorn_demo/cpp_ref/compile.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Compile hand-written PTO-ISA Sinkhorn kernel to outputs/kernel_sinkhorn.so
+# (same call_sinkhorn ABI as caller_sinkhorn_k4.cpp in the parent demo).
+set -euo pipefail
+cd "$(dirname "$0")"
+
+mkdir -p outputs
+
+PTO_ROOT="${PTO_LIB_PATH:-}"
+if [[ -z "${PTO_ROOT}" || ! -f "${PTO_ROOT}/include/pto/pto-inst.hpp" ]]; then
+  PTO_ROOT="/workdir/pto-isa-master"
+fi
+if [[ ! -f "${PTO_ROOT}/include/pto/pto-inst.hpp" ]]; then
+  PTO_ROOT="${PTO_LIB_PATH:-/sources/pto-isa}"
+fi
+
+bisheng \
+  -fPIC -shared -xcce -DMEMORY_BASE \
+  -O2 -std=c++17 -Wno-ignored-attributes \
+  --cce-aicore-arch=dav-c220-vec \
+  "-I${PTO_ROOT}/include" \
+  kernel_sinkhorn.cpp \
+  -o outputs/kernel_sinkhorn.so
+
+echo "Built $(pwd)/outputs/kernel_sinkhorn.so (C++ reference)"

--- a/examples/aot/sinkhorn_demo/cpp_ref/kernel_sinkhorn.cpp
+++ b/examples/aot/sinkhorn_demo/cpp_ref/kernel_sinkhorn.cpp
@@ -1,0 +1,253 @@
+/**
+ * Doubly-stochastic Sinkhorn normalization — minimal PTO demo (fp16, K=4).
+ *
+ * Mirrors DeepSeek TileKernels `sinkhorn_normalize_ref`:
+ *
+ *     x = softmax(x, -1) + eps
+ *     x = x / (colsum(x) + eps)                        # first col normalize
+ *     for _ in range(repeat - 1):
+ *         x = x / (rowsum(x) + eps)                    # row normalize
+ *         x = x / (colsum(x) + eps)                    # col normalize
+ *
+ * Parallelism & batching:
+ *   Each AIV core processes BATCH matrices at a time (one TLOAD for the
+ *   whole group, one TSTORE at the end). The BATCH matrices are stacked
+ *   vertically in UB to form a (BATCH·K)×TILE_DIM tile. This lets us run
+ *   per-matrix-row ops (softmax, row-normalize) as a SINGLE call over the
+ *   whole stack. Column-normalize can't batch the same way (a TCOLSUM
+ *   over the stack would mix columns across matrices), so that step
+ *   loops over the BATCH matrices as independent K×K sub-tiles.
+ *
+ * Fp16 PTO tiles must have row-bytes that are a multiple of 32, i.e. the
+ * tile column dim must be a multiple of 16. K=4 is smaller than that, so
+ * each matrix's row is padded out to 16; the padding cells stay at 0 for
+ * the whole computation.
+ */
+
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+// ---- Problem constants ----
+constexpr uint32_t K         = 4;             // matrix dimension
+constexpr uint32_t TILE_DIM  = 16;            // padded tile col dim (32-byte row alignment for fp16)
+constexpr uint32_t BATCH     = 8;             // matrices processed together per AIV core
+constexpr uint32_t STACK_ROWS = BATCH * K;    // rows of the stacked-matrix tile
+
+#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
+
+// ---- Tile type aliases ----
+// The stacked BATCH×(K×K) matrices as one (BATCH·K, TILE_DIM) tile.
+using Stack = Tile<TileType::Vec, half, STACK_ROWS, TILE_DIM,
+                   BLayout::RowMajor, DYNAMIC, DYNAMIC>;
+
+// 1-D view over the stack (used when we only need elementwise ops on it).
+using StackFlat = Tile<TileType::Vec, half, 1, STACK_ROWS * TILE_DIM,
+                       BLayout::RowMajor, -1, -1>;
+
+// Holds one scalar per row of the stack (= one per matrix-row).
+using StackRowStat = Tile<TileType::Vec, half, STACK_ROWS, 1,
+                          BLayout::ColMajor, DYNAMIC, DYNAMIC>;
+
+// One K×K matrix view (for the per-matrix col-normalize loop).
+using SubMatrix = Tile<TileType::Vec, half, TILE_DIM, TILE_DIM,
+                       BLayout::RowMajor, DYNAMIC, DYNAMIC>;
+
+// Holds one scalar per column of a sub-matrix.
+using SubColStat = Tile<TileType::Vec, half, 1, TILE_DIM,
+                        BLayout::RowMajor, -1, -1>;
+
+// ---- Global-memory view aliases ----
+using GmStride = Stride<1, 1, 1, DYNAMIC, 1>;
+using GmShape  = TileShape2D<half, DYNAMIC, DYNAMIC, Layout::ND>;
+using GmTensor = GlobalTensor<half, GmShape, GmStride, Layout::ND>;
+
+
+AICORE void sinkhornK4(__gm__ half *in, __gm__ half *out,
+                       uint32_t num_matrices, uint32_t repeat, float eps) {
+  // UB memory layout — three (BATCH·K)×TILE_DIM stacks + one vector slot.
+  constexpr unsigned STACK_BYTES  = STACK_ROWS * TILE_DIM * sizeof(half);
+  constexpr unsigned MATRIX_BUF   = 0;
+  constexpr unsigned SCRATCH_BUF  = MATRIX_BUF  + STACK_BYTES;
+  constexpr unsigned ROW_STAT_BUF = SCRATCH_BUF + STACK_BYTES;                       // STACK_ROWS halves
+  constexpr unsigned COL_STAT_BUF = ROW_STAT_BUF + STACK_ROWS * sizeof(half);        // TILE_DIM halves
+
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+
+  const uint32_t num_cores = get_block_num() * get_subblockdim();
+  const uint32_t core_id   = get_block_idx() * get_subblockdim() + get_subblockid();
+  const half     eps_h     = (half)eps;
+
+  // Initial cross-pipe flags — prime them so the first wait_flag below succeeds.
+  set_flag(PIPE_V,    PIPE_MTE2, EVENT_ID0);
+  set_flag(PIPE_MTE3, PIPE_V,    EVENT_ID0);
+
+  // Each AIV core processes a BATCH at a time; cores stride through the batches.
+  for (uint32_t group = core_id * BATCH; group < num_matrices; group += num_cores * BATCH) {
+    const uint32_t actual = min(BATCH, num_matrices - group);  // real matrices in this group (last may be partial)
+    const uint32_t rows   = actual * K;
+
+    __gm__ half *in_gm  = in  + (size_t)group * K * K;
+    __gm__ half *out_gm = out + (size_t)group * K * K;
+
+    // ── Load: zero the whole stack, then TLOAD the `rows` valid matrix-rows ──
+    {
+      StackFlat zeros(1, STACK_ROWS * TILE_DIM);
+      TASSIGN(zeros, MATRIX_BUF);
+      TEXPANDS(zeros, (half)0.f);
+      pipe_barrier(PIPE_V);
+    }
+
+    Stack mat(rows, K);
+    TASSIGN(mat, MATRIX_BUF);
+
+    GmShape  gm_shape(rows, K);
+    GmStride gm_stride(K);
+    GmTensor gm_in(in_gm, gm_shape, gm_stride);
+
+    wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+    TLOAD(mat, gm_in);
+    pipe_barrier(PIPE_ALL);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    // Reusable views of the scratch + row-stat buffers.
+    Stack scratch(rows, K);
+    TASSIGN(scratch, SCRATCH_BUF);
+
+    StackRowStat row_stat(rows, 1);
+    TASSIGN(row_stat, ROW_STAT_BUF);
+
+    // ── Step 1: softmax along the last dim (BATCHED — one call for all matrices) ──
+    //   row_stat[i] = max(mat[i, :])          (K=4 scalars per matrix × BATCH matrices)
+    //   mat[i, :]   = exp(mat[i, :] - row_stat[i])
+    //   row_stat[i] = sum(mat[i, :])
+    //   mat[i, :]   = mat[i, :] / row_stat[i]
+    TROWMAX(row_stat, mat, scratch);
+    pipe_barrier(PIPE_V);
+
+    TROWEXPANDSUB(mat, mat, row_stat);
+    pipe_barrier(PIPE_V);
+
+    {
+      StackFlat flat(1, rows * TILE_DIM);
+      TASSIGN(flat, MATRIX_BUF);
+      TEXP(flat, flat);
+      pipe_barrier(PIPE_V);
+    }
+
+    TROWSUM(row_stat, mat, scratch);
+    pipe_barrier(PIPE_V);
+
+    TROWEXPANDDIV(mat, mat, row_stat);
+    pipe_barrier(PIPE_V);
+
+    // ── Step 2: mat += eps  (batched) ───────────────────────────────────
+    {
+      StackFlat flat(1, rows * TILE_DIM);
+      TASSIGN(flat, MATRIX_BUF);
+      TADDS(flat, flat, eps_h);
+      pipe_barrier(PIPE_V);
+    }
+
+    // ── Step 3: first col-normalize — per-matrix loop ───────────────────
+    //   Column-normalize can't batch across stacked matrices (TCOLSUM on
+    //   the stack would mix cols across matrices), so we loop once over
+    //   each K×K sub-matrix.
+    for (uint32_t m = 0; m < actual; ++m) {
+      const unsigned offset = MATRIX_BUF + m * K * TILE_DIM * sizeof(half);
+
+      SubMatrix  sub_mat(K, K);       TASSIGN(sub_mat,  offset);
+      SubMatrix  sub_scratch(K, K);   TASSIGN(sub_scratch, SCRATCH_BUF + m * K * TILE_DIM * sizeof(half));
+      SubColStat col_stat(1, K);      TASSIGN(col_stat, COL_STAT_BUF);
+
+      TCOLSUM(col_stat, sub_mat, sub_scratch, false);
+      pipe_barrier(PIPE_V);
+
+      TADDS(col_stat, col_stat, eps_h);
+      pipe_barrier(PIPE_V);
+
+      TCOLEXPANDDIV(sub_mat, sub_mat, col_stat);
+      pipe_barrier(PIPE_V);
+    }
+
+    // ── Step 4: (repeat - 1) × { batched row-normalize; per-matrix col-normalize } ──
+    for (uint32_t iter = 1; iter < repeat; ++iter) {
+      // Batched row-normalize.
+      TASSIGN(row_stat, ROW_STAT_BUF);
+
+      TROWSUM(row_stat, mat, scratch);
+      pipe_barrier(PIPE_V);
+
+      TADDS(row_stat, row_stat, eps_h);
+      pipe_barrier(PIPE_V);
+
+      TROWEXPANDDIV(mat, mat, row_stat);
+      pipe_barrier(PIPE_V);
+
+      // Per-matrix col-normalize.
+      for (uint32_t m = 0; m < actual; ++m) {
+        const unsigned offset = MATRIX_BUF + m * K * TILE_DIM * sizeof(half);
+
+        SubMatrix  sub_mat(K, K);      TASSIGN(sub_mat,  offset);
+        SubMatrix  sub_scratch(K, K);  TASSIGN(sub_scratch, SCRATCH_BUF + m * K * TILE_DIM * sizeof(half));
+        SubColStat col_stat(1, K);     TASSIGN(col_stat, COL_STAT_BUF);
+
+        TCOLSUM(col_stat, sub_mat, sub_scratch, false);
+        pipe_barrier(PIPE_V);
+
+        TADDS(col_stat, col_stat, eps_h);
+        pipe_barrier(PIPE_V);
+
+        TCOLEXPANDDIV(sub_mat, sub_mat, col_stat);
+        pipe_barrier(PIPE_V);
+      }
+    }
+
+    // ── Store the valid rows back to GM ─────────────────────────────────
+    GmTensor gm_out(out_gm, gm_shape, gm_stride);
+
+    wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+    TSTORE(gm_out, mat);
+    pipe_barrier(PIPE_ALL);
+
+    set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+    set_flag(PIPE_V,    PIPE_MTE2, EVENT_ID0);
+  }
+
+  // Drain pipelines before exit.
+  wait_flag(PIPE_V,    PIPE_MTE2, EVENT_ID0);
+  wait_flag(PIPE_MTE3, PIPE_V,    EVENT_ID0);
+}
+#endif  // __CCE_AICORE__ == 220 && __DAV_C220_VEC__
+
+
+// ---- C ABI ---------------------------------------------------------------
+
+extern "C" __global__ AICORE void sinkhorn_k4_fp16(
+    __gm__ uint8_t *input, __gm__ uint8_t *output,
+    uint32_t num_matrices, uint32_t repeat, float eps) {
+#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
+  sinkhornK4((__gm__ half *)input, (__gm__ half *)output,
+             num_matrices, repeat, eps);
+#else
+  (void)input;
+  (void)output;
+  (void)num_matrices;
+  (void)repeat;
+  (void)eps;
+#endif
+}
+
+// Host-side launch. Ascend 910B runs 2 AIV cores per cube core.
+extern "C" void call_sinkhorn(
+    uint32_t cube_core_num, void *stream,
+    uint8_t *input, uint8_t *output,
+    uint32_t num_matrices, uint32_t repeat, float eps) {
+  sinkhorn_k4_fp16<<<cube_core_num * 2, nullptr, stream>>>(
+      input, output, num_matrices, repeat, eps);
+}

--- a/examples/aot/sinkhorn_demo/cpp_ref/kernel_sinkhorn_v2.cpp
+++ b/examples/aot/sinkhorn_demo/cpp_ref/kernel_sinkhorn_v2.cpp
@@ -1,0 +1,648 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+See LICENSE in the root of the software repository for the full License text.
+*/
+
+/**
+ * Doubly-stochastic Sinkhorn normalization — Ascend 910B kernel (fp16 I/O, K=4).
+ *
+ * K=4-only specialization of kernel_sinkhorn.cpp's K=4 dispatch paths
+ * (DeepSeek MHC sinkhorn, hc_mult=4).  Drops the K=8/16/32/64/128 paths
+ * and the K-runtime templating so every tile dimension is a compile-time
+ * constant at the ABI boundary.
+ *
+ *     x = x.softmax(-1) + eps
+ *     x = x / (x.sum(-2, keepdim=True) + eps)
+ *     for _ in range(repeat - 1):
+ *         x = x / (x.sum(-1, keepdim=True) + eps)
+ *         x = x / (x.sum(-2, keepdim=True) + eps)
+ *
+ * Two code paths, dispatched on batch size:
+ *
+ *   N >= 2048  — sinkhornFastPath
+ *                Interleaved (K, ROW_BLOCK_COLS) tile + double-buffered
+ *                bulk TLOAD / TSTORE.  Col-normalize = TCOLSUM +
+ *                TCOLEXPANDDIV on the full interleaved tile (2 ops,
+ *                2 barriers per iteration).
+ *
+ *   N <  2048  — sinkhornSmallBatch
+ *                Natural-order layout, no double-buffer.  Per-matrix
+ *                col-normalize with TCOLEXPANDDIV on each 4×4 sub-tile.
+ *                Pays almost no setup cost; wins at small batch.
+ *
+ * Parallelism model (both paths):
+ *   N matrices sharded across AIV cores (num_workers total).  Each worker
+ *   takes an equal slice and processes it in chunks of up to
+ *   CHUNK_MATRICES matrices via one bulk TLOAD + TSTORE per chunk.  Within
+ *   each chunk, matrices are further split into groups of MAX_GROUP_SIZE.
+ *
+ * Epsilon:
+ *   The reference formula adds `eps` to the matrix after softmax and to
+ *   each row/col sum before dividing.  Those adds are elided here (matching
+ *   the multi-K kernel's K=4 path): after softmax every cell is strictly
+ *   positive, so no denominator can be zero, and elision was validated by
+ *   the full shape sweep in test_sinkhorn.py at repeat=10.  Re-introduce
+ *   the three TADDS ops if running at very high iteration counts.
+ */
+
+#include <pto/pto-inst.hpp>
+
+#ifndef GM_ADDR
+#define GM_ADDR __gm__ uint8_t *
+#endif
+
+using namespace pto;
+
+// ==========================================================================
+// Compile-time constants
+// ==========================================================================
+constexpr uint32_t UB_BYTES = 192 * 1024;  // per-AIV unified buffer size
+constexpr uint32_t K = 4;                  // matrix dimension (fixed)
+constexpr uint32_t TILE_COLS =
+    16;  // padded row width (32-byte fp16 alignment)
+constexpr uint32_t STACK_ROWS = 512;  // tall-tile row count
+
+// 32-byte align helper (fp16 PTO tiles require 32-byte-aligned row bytes).
+#define ALIGN_32(x) (((x) + 31u) & ~31u)
+
+#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
+
+// ==========================================================================
+// Tile type aliases
+// ==========================================================================
+template <typename T, uint32_t N>
+using FlatVec = Tile<TileType::Vec, T, 1, N, BLayout::RowMajor, -1, -1>;
+
+template <typename T, uint32_t Rows, uint32_t Cols>
+using Tile2D =
+    Tile<TileType::Vec, T, Rows, Cols, BLayout::RowMajor, DYNAMIC, DYNAMIC>;
+
+template <typename T, uint32_t Rows>
+using ColVec =
+    Tile<TileType::Vec, T, Rows, 1, BLayout::ColMajor, DYNAMIC, DYNAMIC>;
+
+// ==========================================================================
+// Global-memory tensor aliases (contiguous row-major)
+// ==========================================================================
+using GmDenseStride = Stride<1, 1, 1, DYNAMIC, 1>;
+template <typename T>
+using GmShape2D = TileShape2D<T, DYNAMIC, DYNAMIC, Layout::ND>;
+template <typename T, uint32_t Cols>
+using GmTensor = GlobalTensor<T, GmShape2D<T>, GmDenseStride, Layout::ND>;
+
+// ==========================================================================
+// Pipeline-flag helpers
+// ==========================================================================
+AICORE inline void initPipelineFlags() {
+  set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+  set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+}
+
+AICORE inline void drainPipelineFlags() {
+  wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+  wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+}
+
+// ==========================================================================
+// Strided UB→UB copy (wraps copy_ubuf_to_ubuf)
+// ==========================================================================
+namespace pto {
+template <typename TileDescriptor>
+__tf__ AICORE inline void stridedUBCopyImpl(
+    typename TileDescriptor::TileDType __out__ dstTile,
+    typename TileDescriptor::TileDType __in__ srcTile, uint16_t nBurst,
+    uint16_t lenBurst, uint16_t srcGap, uint16_t dstGap) {
+  __ubuf__ void *dst = (__ubuf__ void *)__cce_get_tile_ptr(dstTile);
+  __ubuf__ void *src = (__ubuf__ void *)__cce_get_tile_ptr(srcTile);
+  __builtin_cce_copy_ubuf_to_ubuf(dst, src, (uint8_t)0, nBurst, lenBurst,
+                                  srcGap, dstGap);
+}
+}  // namespace pto
+
+template <typename TileT>
+AICORE inline void stridedUBCopy(TileT &dst, TileT &src, uint16_t nBurst,
+                                 uint16_t lenBurst, uint16_t srcGap,
+                                 uint16_t dstGap) {
+  pto::stridedUBCopyImpl<TileT>(dst.data(), src.data(), nBurst, lenBurst,
+                                srcGap, dstGap);
+}
+
+// ==========================================================================
+// Fast path:  K = 4, N >= 2048  —  TCOLEXPANDDIV on full interleaved tile
+// ==========================================================================
+//
+// Two views of the same physical UB memory:
+//
+//   Tall view       shape (STACK_ROWS, TILE_COLS), row stride = TILE_COLS.
+//                   Used for per-row ops (softmax, row-normalize).
+//                   Matrix i's row r lives at tall-row
+//                   ((i / GS) * K + i % GS + r * GS).
+//
+//   Interleaved     shape (K, ROW_BLOCK_COLS), row stride = ROW_BLOCK_COLS
+//   view                = MAX_GROUP_SIZE * TILE_COLS.
+//                   Used for per-col ops.  Each "column" corresponds to
+//                   one matrix's one column, so TCOLSUM gives per-matrix
+//                   col sums and TCOLEXPANDDIV normalizes correctly.
+//
+// Both views work simultaneously because
+//   tall stride × group size = TILE_COLS × MAX_GROUP_SIZE = ROW_BLOCK_COLS.
+// Partial groups are zero-padded; padding cells softmax to 1/K (benign)
+// and don't leak into valid outputs.
+template <typename T, uint32_t REPEAT>
+AICORE void sinkhornFastPath(__gm__ T *gm_in, __gm__ T *gm_out, uint32_t N,
+                             float eps) {
+  constexpr unsigned TALL_ROWS = STACK_ROWS;
+  constexpr unsigned MAX_GROUP_SIZE = TALL_ROWS / K;
+  constexpr unsigned ROW_BLOCK_COLS = MAX_GROUP_SIZE * TILE_COLS;
+  static_assert(K * ROW_BLOCK_COLS == TALL_ROWS * TILE_COLS,
+                "Interleaved and tall views must cover the same UB region");
+
+  constexpr unsigned MATRIX_ROW_BYTES = TILE_COLS * sizeof(half);
+  constexpr unsigned TILE_BYTES = TALL_ROWS * TILE_COLS * sizeof(half);
+
+  constexpr unsigned SCRATCH_UB = 0;
+  constexpr unsigned WORK_UB = ALIGN_32(SCRATCH_UB + TILE_BYTES);
+  constexpr unsigned ROW_STATS_UB = ALIGN_32(WORK_UB + TILE_BYTES);
+  constexpr unsigned COL_STATS_UB =
+      ALIGN_32(ROW_STATS_UB + ALIGN_32(TALL_ROWS * sizeof(half)));
+  constexpr unsigned BATCH_UB_BASE =
+      ALIGN_32(COL_STATS_UB + ALIGN_32(ROW_BLOCK_COLS * sizeof(half)));
+
+  constexpr unsigned BATCH_HALF_BUDGET = (UB_BYTES - BATCH_UB_BASE) / 2;
+  constexpr unsigned BATCH_HALF_ROWS_RAW =
+      BATCH_HALF_BUDGET / (TILE_COLS * sizeof(half));
+  constexpr unsigned MAX_BATCH_ROWS =
+      BATCH_HALF_ROWS_RAW < 4095 ? BATCH_HALF_ROWS_RAW : 4095;
+  constexpr unsigned BATCH_HALF_BYTES =
+      MAX_BATCH_ROWS * TILE_COLS * sizeof(half);
+  constexpr unsigned BATCH_UB_PING = BATCH_UB_BASE;
+  constexpr unsigned BATCH_UB_PONG = BATCH_UB_BASE + ALIGN_32(BATCH_HALF_BYTES);
+  static_assert(BATCH_UB_PONG + BATCH_HALF_BYTES <= UB_BYTES,
+                "Double-buffered BATCH_UB exceeds UB capacity");
+
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+
+  const uint32_t num_workers = get_block_num() * get_subblockdim();
+  const uint32_t worker_id =
+      get_block_idx() * get_subblockdim() + get_subblockid();
+  const uint32_t base_per_worker = N / num_workers;
+  const uint32_t remainder = N % num_workers;
+  const uint32_t my_first = worker_id * base_per_worker +
+                            (worker_id < remainder ? worker_id : remainder);
+  const uint32_t my_count = base_per_worker + (worker_id < remainder ? 1 : 0);
+  if (my_count == 0) return;
+
+  constexpr uint32_t K_SQUARED = K * K;
+  constexpr uint32_t GROUP_SIZE_STATIC = MAX_GROUP_SIZE;
+  constexpr uint32_t CHUNK_MATRICES = MAX_BATCH_ROWS / K;
+
+  // Prime all four cross-pipe flags (two halves × two directions).
+  set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+  set_flag(PIPE_V, PIPE_MTE2, EVENT_ID1);
+  set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+  set_flag(PIPE_MTE3, PIPE_V, EVENT_ID1);
+
+  bool half_zeroed[2] = {false, false};
+  uint32_t ping = 1;
+  for (uint32_t chunk_offset = 0; chunk_offset < my_count;
+       chunk_offset += CHUNK_MATRICES, ping = 1 - ping) {
+    const uint32_t chunk_matrices =
+        min(CHUNK_MATRICES, my_count - chunk_offset);
+    const uint32_t chunk_rows = chunk_matrices * K;
+    __gm__ T *chunk_gm_in =
+        gm_in + (size_t)(my_first + chunk_offset) * K_SQUARED;
+    __gm__ T *chunk_gm_out =
+        gm_out + (size_t)(my_first + chunk_offset) * K_SQUARED;
+
+    const unsigned batch_ub = ping ? BATCH_UB_PING : BATCH_UB_PONG;
+    const event_t ev = ping ? (event_t)EVENT_ID0 : (event_t)EVENT_ID1;
+
+    Tile2D<T, MAX_BATCH_ROWS, TILE_COLS> batch_tile(chunk_rows, K);
+    TASSIGN(batch_tile, batch_ub);
+
+    GmShape2D<T> gm_shape(chunk_rows, K);
+    GmDenseStride gm_stride(K);
+    GmTensor<T, TILE_COLS> gm_in_tensor(chunk_gm_in, gm_shape, gm_stride);
+
+    wait_flag(PIPE_V, PIPE_MTE2, ev);
+
+    // Lazy-zero: on this half's first use, zero the TILE_COLS - K padding cols.
+    if (!half_zeroed[ping]) {
+      FlatVec<T, MAX_BATCH_ROWS * TILE_COLS> zero_flat(
+          1, MAX_BATCH_ROWS * TILE_COLS);
+      TASSIGN(zero_flat, batch_ub);
+      TEXPANDS(zero_flat, (T)0);
+      pipe_barrier(PIPE_V);
+      half_zeroed[ping] = true;
+    }
+
+    TLOAD(batch_tile, gm_in_tensor);
+    set_flag(PIPE_MTE2, PIPE_V, ev);
+    wait_flag(PIPE_MTE2, PIPE_V, ev);
+    wait_flag(PIPE_MTE3, PIPE_V, ev);
+
+    for (uint32_t group_start = 0; group_start < chunk_matrices;
+         group_start += GROUP_SIZE_STATIC) {
+      const uint32_t group_size =
+          min(GROUP_SIZE_STATIC, chunk_matrices - group_start);
+      const unsigned group_batch_offset =
+          batch_ub + group_start * K * TILE_COLS * sizeof(T);
+
+      constexpr uint16_t tile_row_blocks = TILE_COLS * sizeof(half) / 32;
+      constexpr uint16_t src_gap_blocks = (uint16_t)(K - 1) * tile_row_blocks;
+
+      if (group_size < GROUP_SIZE_STATIC) {
+        FlatVec<T, K * ROW_BLOCK_COLS> work_flat(1, K * ROW_BLOCK_COLS);
+        TASSIGN(work_flat, WORK_UB);
+        TEXPANDS(work_flat, (T)0);
+        pipe_barrier(PIPE_V);
+      }
+
+      // Interleave: BATCH_UB → WORK_UB.
+      for (uint32_t row = 0; row < K; ++row) {
+        Tile2D<half, TALL_ROWS, TILE_COLS> src_view(group_size, K);
+        Tile2D<half, TALL_ROWS, TILE_COLS> dst_view(group_size, K);
+        TASSIGN(src_view, group_batch_offset + row * MATRIX_ROW_BYTES);
+        TASSIGN(dst_view,
+                WORK_UB + row * ROW_BLOCK_COLS * (unsigned)sizeof(half));
+        stridedUBCopy(dst_view, src_view, (uint16_t)group_size, tile_row_blocks,
+                      src_gap_blocks, (uint16_t)0);
+      }
+      pipe_barrier(PIPE_V);
+
+      if constexpr (REPEAT > 0) {
+        Tile2D<half, TALL_ROWS, TILE_COLS> tall_matrix(TALL_ROWS, K);
+        TASSIGN(tall_matrix, WORK_UB);
+
+        Tile2D<half, TALL_ROWS, TILE_COLS> tall_scratch(TALL_ROWS, K);
+        TASSIGN(tall_scratch, SCRATCH_UB);
+
+        ColVec<half, TALL_ROWS> row_stats(TALL_ROWS, 1);
+        TASSIGN(row_stats, ROW_STATS_UB);
+
+        // Softmax along each matrix-row.
+        TROWMAX(row_stats, tall_matrix, tall_scratch);
+        pipe_barrier(PIPE_V);
+
+        TROWEXPANDSUB(tall_matrix, tall_matrix, row_stats);
+        pipe_barrier(PIPE_V);
+
+        {
+          FlatVec<half, TALL_ROWS * TILE_COLS> work_flat(1,
+                                                         TALL_ROWS * TILE_COLS);
+          TASSIGN(work_flat, WORK_UB);
+          TEXP(work_flat, work_flat);
+          pipe_barrier(PIPE_V);
+        }
+
+        TROWSUM(row_stats, tall_matrix, tall_scratch);
+        pipe_barrier(PIPE_V);
+
+        TROWEXPANDDIV(tall_matrix, tall_matrix, row_stats);
+        pipe_barrier(PIPE_V);
+
+        // Col-normalize via the interleaved view.
+        Tile2D<half, K, ROW_BLOCK_COLS> interleaved_matrix(K, ROW_BLOCK_COLS);
+        TASSIGN(interleaved_matrix, WORK_UB);
+
+        Tile2D<half, K, ROW_BLOCK_COLS> interleaved_scratch(K, ROW_BLOCK_COLS);
+        TASSIGN(interleaved_scratch, SCRATCH_UB);
+
+        FlatVec<half, ROW_BLOCK_COLS> col_stats(1, ROW_BLOCK_COLS);
+        TASSIGN(col_stats, COL_STATS_UB);
+
+#define COL_NORMALIZE()                                                \
+  do {                                                                 \
+    TCOLSUM(col_stats, interleaved_matrix, interleaved_scratch, true); \
+    pipe_barrier(PIPE_V);                                              \
+    TCOLEXPANDDIV(interleaved_matrix, interleaved_matrix, col_stats);  \
+    pipe_barrier(PIPE_V);                                              \
+  } while (0)
+
+        COL_NORMALIZE();
+
+#pragma unroll
+        for (uint32_t iter = 1; iter < REPEAT; ++iter) {
+          TASSIGN(row_stats, ROW_STATS_UB);
+
+          TROWSUM(row_stats, tall_matrix, tall_scratch);
+          pipe_barrier(PIPE_V);
+
+          TROWEXPANDDIV(tall_matrix, tall_matrix, row_stats);
+          pipe_barrier(PIPE_V);
+
+          COL_NORMALIZE();
+        }
+#undef COL_NORMALIZE
+      }
+
+      // De-interleave: WORK_UB → BATCH_UB.
+      for (uint32_t row = 0; row < K; ++row) {
+        Tile2D<half, TALL_ROWS, TILE_COLS> src_view(group_size, K);
+        Tile2D<half, TALL_ROWS, TILE_COLS> dst_view(group_size, K);
+        TASSIGN(src_view,
+                WORK_UB + row * ROW_BLOCK_COLS * (unsigned)sizeof(half));
+        TASSIGN(dst_view, group_batch_offset + row * MATRIX_ROW_BYTES);
+        stridedUBCopy(dst_view, src_view, (uint16_t)group_size, tile_row_blocks,
+                      (uint16_t)0, src_gap_blocks);
+      }
+      pipe_barrier(PIPE_V);
+    }
+
+    GmTensor<T, TILE_COLS> gm_out_tensor(chunk_gm_out, gm_shape, gm_stride);
+    set_flag(PIPE_V, PIPE_MTE3, ev);
+    wait_flag(PIPE_V, PIPE_MTE3, ev);
+    TSTORE(gm_out_tensor, batch_tile);
+    set_flag(PIPE_MTE3, PIPE_V, ev);
+    set_flag(PIPE_V, PIPE_MTE2, ev);
+  }
+
+  wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+  wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID1);
+  wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+  wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID1);
+}
+
+// ==========================================================================
+// Small-batch path:  K = 4, N < 2048  —  natural-order, no DB
+// ==========================================================================
+//
+// Fast path's double-buffer + interleave setup costs ~25us per call and is
+// wasted when there's only one chunk per worker.  At K=4, batch=1 this
+// path clocks ~14us vs ~40us for fast-path; crossover is around N=2048.
+template <typename T, uint32_t REPEAT>
+AICORE void sinkhornSmallBatch(__gm__ T *gm_in, __gm__ T *gm_out, uint32_t N,
+                               float eps) {
+  constexpr unsigned TALL_ROWS = STACK_ROWS;
+  constexpr unsigned TILE_BYTES = TALL_ROWS * TILE_COLS * sizeof(half);
+  constexpr unsigned MATRIX_ROW_BYTES = TILE_COLS * sizeof(half);
+
+  constexpr unsigned MAT_UB = 0;
+  constexpr unsigned SCRATCH_UB = ALIGN_32(MAT_UB + TILE_BYTES);
+  constexpr unsigned ROW_STATS_UB = ALIGN_32(SCRATCH_UB + TILE_BYTES);
+  constexpr unsigned BATCH_UB =
+      ALIGN_32(ROW_STATS_UB + ALIGN_32(TALL_ROWS * sizeof(half)));
+  constexpr unsigned BATCH_BUF_ROWS_RAW =
+      (UB_BYTES - BATCH_UB) / (TILE_COLS * sizeof(half));
+  constexpr unsigned MAX_BATCH_ROWS =
+      BATCH_BUF_ROWS_RAW < 4095 ? BATCH_BUF_ROWS_RAW : 4095;
+
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+
+  const uint32_t num_workers = get_block_num() * get_subblockdim();
+  const uint32_t worker_id =
+      get_block_idx() * get_subblockdim() + get_subblockid();
+  const uint32_t base_per_worker = N / num_workers;
+  const uint32_t remainder = N % num_workers;
+  const uint32_t my_first = worker_id * base_per_worker +
+                            (worker_id < remainder ? worker_id : remainder);
+  const uint32_t my_count = base_per_worker + (worker_id < remainder ? 1 : 0);
+  if (my_count == 0) return;
+
+  constexpr uint32_t K_SQUARED = K * K;
+  constexpr uint32_t MAX_GROUP_SIZE = TALL_ROWS / K;
+  constexpr uint32_t CHUNK_MATRICES = MAX_BATCH_ROWS / K;
+  const half eps_h = (half)eps;
+
+  initPipelineFlags();
+
+  for (uint32_t chunk_offset = 0; chunk_offset < my_count;
+       chunk_offset += CHUNK_MATRICES) {
+    const uint32_t chunk_matrices =
+        min(CHUNK_MATRICES, my_count - chunk_offset);
+    const uint32_t chunk_rows = chunk_matrices * K;
+    __gm__ T *chunk_gm_in =
+        gm_in + (size_t)(my_first + chunk_offset) * K_SQUARED;
+    __gm__ T *chunk_gm_out =
+        gm_out + (size_t)(my_first + chunk_offset) * K_SQUARED;
+
+    // Zero BATCH_UB region we're about to load (padding cols stay 0).
+    {
+      FlatVec<T, MAX_BATCH_ROWS * TILE_COLS> zero_flat(1,
+                                                       chunk_rows * TILE_COLS);
+      TASSIGN(zero_flat, BATCH_UB);
+      TEXPANDS(zero_flat, (T)0);
+      pipe_barrier(PIPE_V);
+    }
+
+    Tile2D<T, MAX_BATCH_ROWS, TILE_COLS> batch_tile(chunk_rows, K);
+    TASSIGN(batch_tile, BATCH_UB);
+    GmShape2D<T> gm_shape(chunk_rows, K);
+    GmDenseStride gm_stride(K);
+    GmTensor<T, TILE_COLS> gm_in_tensor(chunk_gm_in, gm_shape, gm_stride);
+
+    wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+    TLOAD(batch_tile, gm_in_tensor);
+    pipe_barrier(PIPE_ALL);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    for (uint32_t group_start = 0; group_start < chunk_matrices;
+         group_start += MAX_GROUP_SIZE) {
+      const uint32_t group_size =
+          min(MAX_GROUP_SIZE, chunk_matrices - group_start);
+      const uint32_t group_rows = group_size * K;
+      const uint32_t group_cells = group_rows * TILE_COLS;
+      const unsigned group_batch_offset =
+          BATCH_UB + group_start * K * TILE_COLS * sizeof(T);
+
+      // Copy BATCH_UB → MAT_UB (natural order, same stride).
+      {
+        FlatVec<T, TALL_ROWS * TILE_COLS> zero_mat(1, TALL_ROWS * TILE_COLS);
+        TASSIGN(zero_mat, MAT_UB);
+        TEXPANDS(zero_mat, (T)0);
+        pipe_barrier(PIPE_V);
+      }
+      {
+        FlatVec<T, TALL_ROWS * TILE_COLS> src(1, group_cells);
+        FlatVec<T, TALL_ROWS * TILE_COLS> dst(1, group_cells);
+        TASSIGN(src, group_batch_offset);
+        TASSIGN(dst, MAT_UB);
+        TMOV(dst, src);
+        pipe_barrier(PIPE_V);
+      }
+
+      Tile2D<half, TALL_ROWS, TILE_COLS> tall_matrix(group_rows, K);
+      TASSIGN(tall_matrix, MAT_UB);
+      Tile2D<half, TALL_ROWS, TILE_COLS> tall_scratch(group_rows, K);
+      TASSIGN(tall_scratch, SCRATCH_UB);
+      ColVec<half, TALL_ROWS> row_stats(group_rows, 1);
+      TASSIGN(row_stats, ROW_STATS_UB);
+
+      if constexpr (REPEAT > 0) {
+        TROWMAX(row_stats, tall_matrix, tall_scratch);
+        pipe_barrier(PIPE_V);
+
+        TROWEXPANDSUB(tall_matrix, tall_matrix, row_stats);
+        pipe_barrier(PIPE_V);
+
+        {
+          FlatVec<half, TALL_ROWS * TILE_COLS> flat(1, group_cells);
+          TASSIGN(flat, MAT_UB);
+          TEXP(flat, flat);
+          pipe_barrier(PIPE_V);
+        }
+
+        TROWSUM(row_stats, tall_matrix, tall_scratch);
+        pipe_barrier(PIPE_V);
+
+        TROWEXPANDDIV(tall_matrix, tall_matrix, row_stats);
+        pipe_barrier(PIPE_V);
+
+        // Matches reference `x = x.softmax(-1) + eps`.  Kept on this path
+        // because per-matrix col-normalize (below) divides by raw col
+        // sums without adding eps — fp16 drift over 10 iterations
+        // otherwise grows past the test's rtol.
+        {
+          FlatVec<half, TALL_ROWS * TILE_COLS> flat(1, group_cells);
+          TASSIGN(flat, MAT_UB);
+          TADDS(flat, flat, eps_h);
+          pipe_barrier(PIPE_V);
+        }
+
+#define PER_MATRIX_COL_NORM()                                      \
+  do {                                                             \
+    for (uint32_t mi = 0; mi < group_size; ++mi) {                 \
+      const unsigned mat_off = MAT_UB + mi * K * MATRIX_ROW_BYTES; \
+      Tile2D<half, TILE_COLS, TILE_COLS> sub_mat(K, K);            \
+      TASSIGN(sub_mat, mat_off);                                   \
+      Tile2D<half, TILE_COLS, TILE_COLS> sub_scratch(K, K);        \
+      TASSIGN(sub_scratch, SCRATCH_UB);                            \
+      FlatVec<half, TILE_COLS> col_stats(1, K);                    \
+      TASSIGN(col_stats, ROW_STATS_UB);                            \
+      TCOLSUM(col_stats, sub_mat, sub_scratch, false);             \
+      pipe_barrier(PIPE_V);                                        \
+      TCOLEXPANDDIV(sub_mat, sub_mat, col_stats);                  \
+      pipe_barrier(PIPE_V);                                        \
+    }                                                              \
+  } while (0)
+
+        PER_MATRIX_COL_NORM();
+
+#pragma unroll
+        for (uint32_t iter = 1; iter < REPEAT; ++iter) {
+          TASSIGN(row_stats, ROW_STATS_UB);
+          TROWSUM(row_stats, tall_matrix, tall_scratch);
+          pipe_barrier(PIPE_V);
+
+          TROWEXPANDDIV(tall_matrix, tall_matrix, row_stats);
+          pipe_barrier(PIPE_V);
+
+          PER_MATRIX_COL_NORM();
+        }
+#undef PER_MATRIX_COL_NORM
+      }
+
+      // Copy back MAT_UB → BATCH_UB.
+      {
+        FlatVec<T, TALL_ROWS * TILE_COLS> src(1, group_cells);
+        FlatVec<T, TALL_ROWS * TILE_COLS> dst(1, group_cells);
+        TASSIGN(src, MAT_UB);
+        TASSIGN(dst, group_batch_offset);
+        TMOV(dst, src);
+        pipe_barrier(PIPE_V);
+      }
+    }
+
+    GmTensor<T, TILE_COLS> gm_out_tensor(chunk_gm_out, gm_shape, gm_stride);
+    wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(gm_out_tensor, batch_tile);
+    pipe_barrier(PIPE_ALL);
+    set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+    set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+  }
+
+  drainPipelineFlags();
+}
+
+// ==========================================================================
+// Dispatch
+// ==========================================================================
+// K is fixed at 4.  Batch-size threshold (N=2048) empirically taken from
+// msprof + direct Event timing on 910B: below it the fast-path's
+// interleave + double-buffer setup overhead dominates.
+template <typename T, uint32_t REPEAT>
+AICORE void dispatchByBatch(__gm__ T *gm_in, __gm__ T *gm_out, uint32_t N,
+                            float eps) {
+  if (N >= 2048)
+    sinkhornFastPath<T, REPEAT>(gm_in, gm_out, N, eps);
+  else
+    sinkhornSmallBatch<T, REPEAT>(gm_in, gm_out, N, eps);
+}
+
+// Specialize on `repeat` so that the per-iteration unroll constant is known.
+template <typename T>
+AICORE void dispatchByRepeat(__gm__ T *gm_in, __gm__ T *gm_out, uint32_t N,
+                             uint32_t repeat, float eps) {
+  switch (repeat) {
+    case 0:
+      dispatchByBatch<T, 0>(gm_in, gm_out, N, eps);
+      break;
+    case 1:
+      dispatchByBatch<T, 1>(gm_in, gm_out, N, eps);
+      break;
+    case 3:
+      dispatchByBatch<T, 3>(gm_in, gm_out, N, eps);
+      break;
+    case 5:
+      dispatchByBatch<T, 5>(gm_in, gm_out, N, eps);
+      break;
+    case 8:
+      dispatchByBatch<T, 8>(gm_in, gm_out, N, eps);
+      break;
+    case 10:
+      dispatchByBatch<T, 10>(gm_in, gm_out, N, eps);
+      break;
+    case 20:
+      dispatchByBatch<T, 20>(gm_in, gm_out, N, eps);
+      break;
+    default:
+      dispatchByBatch<T, 10>(gm_in, gm_out, N, eps);
+      break;
+  }
+}
+#endif  // __CCE_AICORE__ == 220 && __DAV_C220_VEC__
+
+// ==========================================================================
+// C ABI
+// ==========================================================================
+// ABI signature keeps `K` for source compatibility with the multi-K wrapper;
+// this kernel is hard-coded to K=4 and ignores the argument.
+extern "C" __global__ AICORE void sinkhorn_ds_fp16(GM_ADDR input,
+                                                   GM_ADDR output, uint32_t N,
+                                                   uint32_t K_arg,
+                                                   uint32_t repeat, float eps) {
+#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
+  (void)K_arg;
+  dispatchByRepeat<half>((__gm__ half *)input, (__gm__ half *)output, N, repeat,
+                         eps);
+#else
+  (void)input;
+  (void)output;
+  (void)N;
+  (void)K_arg;
+  (void)repeat;
+  (void)eps;
+#endif
+}
+
+// Host-side launch.  Ascend 910B runs 2 AIV cores per cube core.
+extern "C" void call_sinkhorn_ds_kernel(uint32_t cube_core_num, void *stream,
+                                        uint8_t *input, uint8_t *output,
+                                        uint32_t N, uint32_t K, uint32_t repeat,
+                                        float eps) {
+  sinkhorn_ds_fp16<<<cube_core_num * 2, nullptr, stream>>>(input, output, N, K,
+                                                           repeat, eps);
+}
+
+// Demo / ctypes ABI (same as ``kernel_sinkhorn.cpp`` in this directory).
+extern "C" void call_sinkhorn(uint32_t cube_core_num, void *stream,
+                              uint8_t *input, uint8_t *output, uint32_t num_matrices,
+                              uint32_t repeat, float eps) {
+  call_sinkhorn_ds_kernel(cube_core_num, stream, input, output, num_matrices, 4,
+                          repeat, eps);
+}

--- a/examples/aot/sinkhorn_demo/cpp_ref/kernel_sinkhorn_v2.cpp
+++ b/examples/aot/sinkhorn_demo/cpp_ref/kernel_sinkhorn_v2.cpp
@@ -46,6 +46,7 @@ See LICENSE in the root of the software repository for the full License text.
  */
 
 #include <pto/pto-inst.hpp>
+#include <pto/npu/a2a3/TCopy.hpp>
 
 #ifndef GM_ADDR
 #define GM_ADDR __gm__ uint8_t *
@@ -104,27 +105,37 @@ AICORE inline void drainPipelineFlags() {
 }
 
 // ==========================================================================
-// Strided UB→UB copy (wraps copy_ubuf_to_ubuf)
+// Interleave / de-interleave row stripes (BATCH_UB ↔ WORK_UB)
+//
+// Implemented with ``pto::TCopy`` on matching 2D tile views so the same
+// pattern maps cleanly to PTODSL ``tile`` UB copies (stride + validRow /
+// validCol) instead of calling ``__builtin_cce_copy_ubuf_to_ubuf`` directly.
+// For each within-matrix row index ``row`` (0..K-1), we copy ``group_size``
+// rows; source stride in batch layout is ``K * TILE_COLS`` half elements
+// between matrices, destination stride in WORK is ``TILE_COLS`` half
+// elements per tall row.  ``validCol == K`` selects the ``validCol < Cols``
+// branch of ``TCopy.hpp`` (per-row ``copy_ubuf_to_ubuf`` with blockLen from
+// ``K``).  De-interleave swaps strides.
 // ==========================================================================
-namespace pto {
-template <typename TileDescriptor>
-__tf__ AICORE inline void stridedUBCopyImpl(
-    typename TileDescriptor::TileDType __out__ dstTile,
-    typename TileDescriptor::TileDType __in__ srcTile, uint16_t nBurst,
-    uint16_t lenBurst, uint16_t srcGap, uint16_t dstGap) {
-  __ubuf__ void *dst = (__ubuf__ void *)__cce_get_tile_ptr(dstTile);
-  __ubuf__ void *src = (__ubuf__ void *)__cce_get_tile_ptr(srcTile);
-  __builtin_cce_copy_ubuf_to_ubuf(dst, src, (uint8_t)0, nBurst, lenBurst,
-                                  srcGap, dstGap);
-}
-}  // namespace pto
 
-template <typename TileT>
-AICORE inline void stridedUBCopy(TileT &dst, TileT &src, uint16_t nBurst,
-                                 uint16_t lenBurst, uint16_t srcGap,
-                                 uint16_t dstGap) {
-  pto::stridedUBCopyImpl<TileT>(dst.data(), src.data(), nBurst, lenBurst,
-                                srcGap, dstGap);
+template <typename TileHalf>
+AICORE inline void sinkhornInterleaveRowStripeUB(TileHalf &dst_view,
+                                               TileHalf &src_view,
+                                               uint64_t group_size) {
+  constexpr unsigned SrcStrideHalf = K * TILE_COLS;
+  constexpr unsigned DstStrideHalf = TILE_COLS;
+  pto::TCopy<TileHalf, TileHalf, 1, SrcStrideHalf, DstStrideHalf>(
+      dst_view.data(), src_view.data(), group_size, K);
+}
+
+template <typename TileHalf>
+AICORE inline void sinkhornDeinterleaveRowStripeUB(TileHalf &dst_view,
+                                                 TileHalf &src_view,
+                                                 uint64_t group_size) {
+  constexpr unsigned SrcStrideHalf = TILE_COLS;
+  constexpr unsigned DstStrideHalf = K * TILE_COLS;
+  pto::TCopy<TileHalf, TileHalf, 1, SrcStrideHalf, DstStrideHalf>(
+      dst_view.data(), src_view.data(), group_size, K);
 }
 
 // ==========================================================================
@@ -249,9 +260,6 @@ AICORE void sinkhornFastPath(__gm__ T *gm_in, __gm__ T *gm_out, uint32_t N,
       const unsigned group_batch_offset =
           batch_ub + group_start * K * TILE_COLS * sizeof(T);
 
-      constexpr uint16_t tile_row_blocks = TILE_COLS * sizeof(half) / 32;
-      constexpr uint16_t src_gap_blocks = (uint16_t)(K - 1) * tile_row_blocks;
-
       if (group_size < GROUP_SIZE_STATIC) {
         FlatVec<T, K * ROW_BLOCK_COLS> work_flat(1, K * ROW_BLOCK_COLS);
         TASSIGN(work_flat, WORK_UB);
@@ -266,8 +274,7 @@ AICORE void sinkhornFastPath(__gm__ T *gm_in, __gm__ T *gm_out, uint32_t N,
         TASSIGN(src_view, group_batch_offset + row * MATRIX_ROW_BYTES);
         TASSIGN(dst_view,
                 WORK_UB + row * ROW_BLOCK_COLS * (unsigned)sizeof(half));
-        stridedUBCopy(dst_view, src_view, (uint16_t)group_size, tile_row_blocks,
-                      src_gap_blocks, (uint16_t)0);
+        sinkhornInterleaveRowStripeUB(dst_view, src_view, group_size);
       }
       pipe_barrier(PIPE_V);
 
@@ -344,8 +351,7 @@ AICORE void sinkhornFastPath(__gm__ T *gm_in, __gm__ T *gm_out, uint32_t N,
         TASSIGN(src_view,
                 WORK_UB + row * ROW_BLOCK_COLS * (unsigned)sizeof(half));
         TASSIGN(dst_view, group_batch_offset + row * MATRIX_ROW_BYTES);
-        stridedUBCopy(dst_view, src_view, (uint16_t)group_size, tile_row_blocks,
-                      (uint16_t)0, src_gap_blocks);
+        sinkhornDeinterleaveRowStripeUB(dst_view, src_view, group_size);
       }
       pipe_barrier(PIPE_V);
     }

--- a/examples/aot/sinkhorn_demo/jit_util_sinkhorn.py
+++ b/examples/aot/sinkhorn_demo/jit_util_sinkhorn.py
@@ -65,6 +65,11 @@ def _load_kernel(so_path: Path) -> ctypes.CDLL:
     return _libs[key]
 
 
+def load_sinkhorn_host_lib(so_path: Path) -> ctypes.CDLL:
+    """Load any shared library exporting ``call_sinkhorn`` (same ABI as this demo)."""
+    return _load_kernel(so_path)
+
+
 def _run_kernel(
     lib: ctypes.CDLL,
     x: torch.Tensor,
@@ -118,12 +123,24 @@ def bench_sinkhorn_forward_gbs(
     repeat: int,
     eps: float,
     *,
-    impl: str,
+    impl: str | None = None,
+    lib: ctypes.CDLL | None = None,
     warmup: int = 5,
     iters: int = 20,
 ) -> float:
-    """Median effective GB/s for one forward pass (read input + write output)."""
-    lib = _load_kernel(_KERNEL_SO_BATCHED if impl == "batched" else _KERNEL_SO_NAIVE)
+    """Median effective GB/s for one forward pass (read input + write output).
+
+    Pass exactly one of ``impl`` (``"batched"`` or ``"naive"`` — loads this
+    demo's ``outputs/*.so``) or ``lib`` (any ``call_sinkhorn`` host ABI, e.g.
+    hand-written ``cpp_ref/kernel_sinkhorn.cpp`` in this demo).
+    """
+    if lib is None:
+        if impl is None:
+            raise ValueError("bench_sinkhorn_forward_gbs requires impl or lib")
+        lib = _load_kernel(_KERNEL_SO_BATCHED if impl == "batched" else _KERNEL_SO_NAIVE)
+    elif impl is not None:
+        raise ValueError("pass only one of impl and lib")
+
     x_flat = x.reshape(-1, 4, 4).contiguous()
     out_flat = torch.empty_like(x_flat)
     nmat = x_flat.shape[0]

--- a/examples/aot/sinkhorn_demo/jit_util_sinkhorn.py
+++ b/examples/aot/sinkhorn_demo/jit_util_sinkhorn.py
@@ -1,16 +1,28 @@
 """
-The device kernel is loaded from ``outputs/kernel_sinkhorn.so``, which must be
-built first (see ``compile.sh`` in this directory).
+The device kernels are loaded from ``outputs/kernel_sinkhorn.so`` (batched
+BATCH=8 stack load) and ``outputs/kernel_sinkhorn_naive.so`` (one matrix per
+vector iteration). Build both via ``compile.sh``.
 """
 
 import ctypes
+import time
 from pathlib import Path
 
 import torch
 
-
 _HERE = Path(__file__).resolve().parent
-_KERNEL_SO = _HERE / "outputs" / "kernel_sinkhorn.so"
+_KERNEL_SO_BATCHED = _HERE / "outputs" / "kernel_sinkhorn.so"
+_KERNEL_SO_NAIVE = _HERE / "outputs" / "kernel_sinkhorn_naive.so"
+
+_KERNEL_ARGTYPES = [
+    ctypes.c_uint32,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_uint32,
+    ctypes.c_uint32,
+    ctypes.c_float,
+]
 
 
 def sinkhorn_normalize_ref(
@@ -25,44 +37,43 @@ def sinkhorn_normalize_ref(
     return x
 
 
-_KERNEL_ARGTYPES = [
-    ctypes.c_uint32,
-    ctypes.c_void_p,
-    ctypes.c_void_p,
-    ctypes.c_void_p,
-    ctypes.c_uint32,
-    ctypes.c_uint32,
-    ctypes.c_float,
-]
+def bandwidth_gbs(data_bytes: int, duration_us: float) -> float:
+    """Effective GB/s (decimal 1e9), matching ``bench_common.bandwidth_gbs``."""
+    return (data_bytes / 1e9) / (duration_us / 1e6) if duration_us > 0 else 0.0
 
 
-def _kernel_so_missing_message() -> str:
+def _kernel_so_missing_message(path: Path) -> str:
     return (
-        f"Kernel shared library not found: {_KERNEL_SO}\n"
-        "Build it first from this example directory, for example:\n"
+        f"Kernel shared library not found: {path}\n"
+        "Build kernels from this example directory, for example:\n"
         "  cd examples/aot/sinkhorn_demo && ./compile.sh"
     )
 
 
-def _load_kernel() -> ctypes.CDLL:
-    """Load ``call_sinkhorn`` from a pre-built ``outputs/kernel_sinkhorn.so``."""
-    if not _KERNEL_SO.is_file():
-        raise FileNotFoundError(_kernel_so_missing_message())
-    lib = ctypes.CDLL(str(_KERNEL_SO))
-    lib.call_sinkhorn.argtypes = _KERNEL_ARGTYPES
-    lib.call_sinkhorn.restype = None
-    return lib
+_libs: dict[str, ctypes.CDLL] = {}
 
 
-_lib = None
+def _load_kernel(so_path: Path) -> ctypes.CDLL:
+    if not so_path.is_file():
+        raise FileNotFoundError(_kernel_so_missing_message(so_path))
+    key = str(so_path)
+    if key not in _libs:
+        lib = ctypes.CDLL(str(so_path))
+        lib.call_sinkhorn.argtypes = _KERNEL_ARGTYPES
+        lib.call_sinkhorn.restype = None
+        _libs[key] = lib
+    return _libs[key]
 
 
-def _run_kernel(x: torch.Tensor, out: torch.Tensor, repeat: int, eps: float) -> None:
-    global _lib
-    if _lib is None:
-        _lib = _load_kernel()
+def _run_kernel(
+    lib: ctypes.CDLL,
+    x: torch.Tensor,
+    out: torch.Tensor,
+    repeat: int,
+    eps: float,
+) -> None:
     dev = torch.npu.current_device()
-    _lib.call_sinkhorn(
+    lib.call_sinkhorn(
         torch.npu.get_device_properties(dev).cube_core_num,
         torch.npu.current_stream()._as_parameter_,
         ctypes.c_void_p(x.data_ptr()),
@@ -74,13 +85,61 @@ def _run_kernel(x: torch.Tensor, out: torch.Tensor, repeat: int, eps: float) -> 
 
 
 def sinkhorn_normalize(
-    x: torch.Tensor, repeat: int = 10, eps: float = 1e-6
+    x: torch.Tensor,
+    repeat: int = 10,
+    eps: float = 1e-6,
+    *,
+    impl: str = "batched",
 ) -> torch.Tensor:
-    """Run the PTO kernel (forward only). ``x`` must be fp16 on NPU, shape ``(..., 4, 4)``."""
+    """Run the PTO kernel (forward only). ``x`` must be fp16 on NPU, shape ``(..., 4, 4)``.
+
+    impl:
+      ``"batched"`` — ``sinkhorn_batch8_builder.py`` (stacked load, matches jit C++ demo).
+      ``"naive"`` — ``sinkhorn_k4_builder.py`` (one matrix per inner iteration).
+    """
     assert x.dtype == torch.float16, "demo requires fp16"
     assert x.shape[-2:] == (4, 4), "demo supports K=4 only"
+    if impl == "batched":
+        so = _KERNEL_SO_BATCHED
+    elif impl == "naive":
+        so = _KERNEL_SO_NAIVE
+    else:
+        raise ValueError(f"impl must be 'batched' or 'naive', got {impl!r}")
+
     x_flat = x.reshape(-1, 4, 4).contiguous()
     out_flat = torch.empty_like(x_flat)
-    _run_kernel(x_flat, out_flat, repeat, eps)
+    _run_kernel(_load_kernel(so), x_flat, out_flat, repeat, eps)
     torch.npu.synchronize()
     return out_flat.reshape_as(x)
+
+
+def bench_sinkhorn_forward_gbs(
+    x: torch.Tensor,
+    repeat: int,
+    eps: float,
+    *,
+    impl: str,
+    warmup: int = 5,
+    iters: int = 20,
+) -> float:
+    """Median effective GB/s for one forward pass (read input + write output)."""
+    lib = _load_kernel(_KERNEL_SO_BATCHED if impl == "batched" else _KERNEL_SO_NAIVE)
+    x_flat = x.reshape(-1, 4, 4).contiguous()
+    out_flat = torch.empty_like(x_flat)
+    nmat = x_flat.shape[0]
+    bytes_rw = 2 * nmat * 4 * 4 * 2  # read fp16 + write fp16
+
+    for _ in range(warmup):
+        _run_kernel(lib, x_flat, out_flat, repeat, eps)
+    torch.npu.synchronize()
+
+    times_us: list[float] = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        _run_kernel(lib, x_flat, out_flat, repeat, eps)
+        torch.npu.synchronize()
+        times_us.append((time.perf_counter() - t0) * 1e6)
+
+    times_us.sort()
+    med_us = times_us[len(times_us) // 2]
+    return bandwidth_gbs(bytes_rw, med_us)

--- a/examples/aot/sinkhorn_demo/jit_util_sinkhorn.py
+++ b/examples/aot/sinkhorn_demo/jit_util_sinkhorn.py
@@ -1,7 +1,8 @@
 """
 The device kernels are loaded from ``outputs/kernel_sinkhorn.so`` (batched
-BATCH=8 stack load) and ``outputs/kernel_sinkhorn_naive.so`` (one matrix per
-vector iteration). Build both via ``compile.sh``.
+BATCH=8 stack load), ``outputs/kernel_sinkhorn_naive.so`` (one matrix per
+vector iteration), and ``outputs/kernel_sinkhorn_v2.so`` (v2-style interleaved
+column normalize). Build them via ``compile.sh``.
 """
 
 import ctypes
@@ -13,6 +14,7 @@ import torch
 _HERE = Path(__file__).resolve().parent
 _KERNEL_SO_BATCHED = _HERE / "outputs" / "kernel_sinkhorn.so"
 _KERNEL_SO_NAIVE = _HERE / "outputs" / "kernel_sinkhorn_naive.so"
+_KERNEL_SO_V2 = _HERE / "outputs" / "kernel_sinkhorn_v2.so"
 
 _KERNEL_ARGTYPES = [
     ctypes.c_uint32,
@@ -101,6 +103,7 @@ def sinkhorn_normalize(
     impl:
       ``"batched"`` — ``sinkhorn_batch8_builder.py`` (stacked load, matches jit C++ demo).
       ``"naive"`` — ``sinkhorn_k4_builder.py`` (one matrix per inner iteration).
+      ``"v2"`` — ``sinkhorn_v2_builder.py`` (interleaved col norm for large ``N``).
     """
     assert x.dtype == torch.float16, "demo requires fp16"
     assert x.shape[-2:] == (4, 4), "demo supports K=4 only"
@@ -108,8 +111,10 @@ def sinkhorn_normalize(
         so = _KERNEL_SO_BATCHED
     elif impl == "naive":
         so = _KERNEL_SO_NAIVE
+    elif impl == "v2":
+        so = _KERNEL_SO_V2
     else:
-        raise ValueError(f"impl must be 'batched' or 'naive', got {impl!r}")
+        raise ValueError(f"impl must be 'batched', 'naive', or 'v2', got {impl!r}")
 
     x_flat = x.reshape(-1, 4, 4).contiguous()
     out_flat = torch.empty_like(x_flat)
@@ -130,14 +135,22 @@ def bench_sinkhorn_forward_gbs(
 ) -> float:
     """Median effective GB/s for one forward pass (read input + write output).
 
-    Pass exactly one of ``impl`` (``"batched"`` or ``"naive"`` — loads this
-    demo's ``outputs/*.so``) or ``lib`` (any ``call_sinkhorn`` host ABI, e.g.
-    hand-written ``cpp_ref/kernel_sinkhorn.cpp`` in this demo).
+    Pass exactly one of ``impl`` (``"batched"``, ``"naive"``, or ``"v2"`` —
+    loads this demo's ``outputs/*.so``) or ``lib`` (any ``call_sinkhorn`` host
+    ABI, e.g. hand-written ``cpp_ref/kernel_sinkhorn.cpp`` in this demo).
     """
     if lib is None:
         if impl is None:
             raise ValueError("bench_sinkhorn_forward_gbs requires impl or lib")
-        lib = _load_kernel(_KERNEL_SO_BATCHED if impl == "batched" else _KERNEL_SO_NAIVE)
+        if impl == "batched":
+            so = _KERNEL_SO_BATCHED
+        elif impl == "naive":
+            so = _KERNEL_SO_NAIVE
+        elif impl == "v2":
+            so = _KERNEL_SO_V2
+        else:
+            raise ValueError(impl)
+        lib = _load_kernel(so)
     elif impl is not None:
         raise ValueError("pass only one of impl and lib")
 

--- a/examples/aot/sinkhorn_demo/remaining_issue.md
+++ b/examples/aot/sinkhorn_demo/remaining_issue.md
@@ -14,9 +14,11 @@ Closing the performance gap requires either **proving or encoding** the interlea
 
 ## Current blockers (Python v2 vs C++ v2)
 
-### 1. No first-class strided UB ↔ UB layout transform
+### 1. No first-class strided UB ↔ UB layout transform in PTODSL
 
-C++ v2 uses `stridedUBCopy` (burst length + `srcGap` / `dstGap` in 32-byte block units) to move data between **batch order** and **tall / interleaved** UB views. PTODSL today relies on **`tile.mov` on row stripes** and/or **`tile.reshape`**. Reshape is only safe when its linearization is **identical** to the layout produced by the reference’s strided copy. Without a binding to the same copy primitive (or a verified lowering of reshape to it), the interleaved fast path is either **wrong** (NaNs) or **unavailable**.
+The C++ v2 reference (`cpp_ref/kernel_sinkhorn_v2.cpp`) interleaves / de-interleaves each within-matrix row using **`pto::TCopy`** on **`Tile2D<half, TALL_ROWS, TILE_COLS>`** views (`#include <pto/npu/a2a3/TCopy.hpp>`): `validRow = group_size`, `validCol = K`, and compile-time **half-element row strides** `K * TILE_COLS` (batch) and `TILE_COLS` (WORK). That matches the former `copy_ubuf_to_ubuf` burst pattern without calling **`__builtin_cce_copy_ubuf_to_ubuf`** from the demo kernel.
+
+PTODSL still has no direct equivalent: authors rely on **`tile.mov` on row stripes** and/or **`tile.reshape`**. Reshape is only safe when its linearization is **identical** to the layout produced by the same `TCopy` semantics. A Python binding that lowers to **`TCopy`** (or the same `copy_ubuf_to_ubuf` row loop with explicit strides) would align the interleaved fast path with this reference.
 
 ### 2. Batched column normalize vs per-matrix `col_sum` loop
 

--- a/examples/aot/sinkhorn_demo/remaining_issue.md
+++ b/examples/aot/sinkhorn_demo/remaining_issue.md
@@ -1,0 +1,92 @@
+# Remaining issues: PTODSL Sinkhorn v2 vs hand-written C++ v2
+
+This note captures why **`sinkhorn_v2_builder.py`** (Python / MLIR PTO) does not yet reach the effective bandwidth of **`cpp_ref/kernel_sinkhorn_v2.cpp`**, and what would help close the gap. It is written from the Sinkhorn-K=4 demo (`examples/aot/sinkhorn_demo`).
+
+## Executive summary
+
+The reference C++ v2 kernel wins mainly by (1) **one batched column reduction per Sinkhorn phase** on an **interleaved** UB layout (`TCOLSUM` on a `(K, ROW_BLOCK_COLS)` view), (2) **strided UB copies** for interleave / de-interleave that match that layout exactly, and (3) **large per-chunk work** (double-buffered batch tiles sized from UB budget) with explicit pipeline flags.
+
+The PTODSL v2 large-`N` path today uses a **correct** but more conservative strategy: a **32-matrix stack** with the same row-softmax fusion as `sinkhorn_batch8_builder.py`, plus a **`pto.range` loop over matrices** for column normalize. That avoids a subtle layout bug we hit when combining **manual row permute** with **`tile.reshape`** to an interleaved tile type: numerically the result diverged (NaNs) because the reshape reinterpretation did not match the C++ strided layout byte-for-byte.
+
+Closing the performance gap requires either **proving or encoding** the interleaved memory map in PTODSL, or **new primitives / compiler behavior** below.
+
+---
+
+## Current blockers (Python v2 vs C++ v2)
+
+### 1. No first-class strided UB ↔ UB layout transform
+
+C++ v2 uses `stridedUBCopy` (burst length + `srcGap` / `dstGap` in 32-byte block units) to move data between **batch order** and **tall / interleaved** UB views. PTODSL today relies on **`tile.mov` on row stripes** and/or **`tile.reshape`**. Reshape is only safe when its linearization is **identical** to the layout produced by the reference’s strided copy. Without a binding to the same copy primitive (or a verified lowering of reshape to it), the interleaved fast path is either **wrong** (NaNs) or **unavailable**.
+
+### 2. Batched column normalize vs per-matrix `col_sum` loop
+
+With the safe batch-32 stack, each Sinkhorn phase runs **up to 32 `tile.col_sum` calls** (plus `eps` and `col_expand_div`) instead of **one** `TCOLSUM` over `(K, ROW_BLOCK_COLS)`. On generated code this tends to mean **more vector barriers and less amortized reduction** than C++ v2’s macro (`TCOLSUM` + `TCOLEXPANDDIV` + barriers) on the full interleaved tile.
+
+### 3. Chunk / tile sizing vs UB budget
+
+C++ v2 computes **`MAX_BATCH_ROWS`** from half the UB budget (minus row/col stat regions) and double-buffers, so each **TLOAD** amortizes over many matrices. PTODSL v2 is constrained by **static `TileBufType` shapes**, **`tile.mov` / subview static size rules**, and practical UB limits on 910B. The Python path uses a **fixed 128-row stack (32 matrices)**; the reference can use **substantially larger** batch tiles where memory allows.
+
+### 4. Static subview sizes vs dynamic `valid_row` / chunk length
+
+MLIR `SubViewOp` sizes observed in this demo are **compile-time integers**. Dynamic **`chunk_rows`** / **`chunk_mat`** must be expressed via **`valid_row` on `alloc_tile`** plus **fixed maximum** subview extents (`MAX_BATCH_ROWS`, `K`, etc.). That is workable but limits expressiveness for **generic** “size this tile from SSA budget” patterns the C++ side encodes with template + runtime `min`.
+
+### 5. `pto.tcolsum` / `isBinary` coupling in `ptoas`
+
+Experimentally, lowering **`tile.col_sum(..., is_binary=False)`** failed in `ptoas` with: the temporary operand **requires** the `isBinary` attribute. That blocks exploring alternate reduction semantics where Python might match a different hardware path, and it couples Python surface area to whatever `ptoas` currently accepts for tmp operands.
+
+---
+
+## Feature requests: MLIR PTO Python bindings (`ptodsl`)
+
+These are ordered roughly by impact for the Sinkhorn v2 case; each should come with **documented memory order** (row-major rules, 32-byte alignment, interaction with `valid_row` / `valid_col`).
+
+1. **Strided UB copy (or `tile.copy_ub_strided`)**  
+   Expose the same capability as the C++ `stridedUBCopy` / `__builtin_cce_copy_ubuf_to_ubuf` path: `nBurst`, `lenBurst`, `srcGap`, `dstGap`, with tile descriptors for source and destination. Use cases: interleave, de-interleave, and other **non-contiguous** UB reorganizations without guessing reshape linearization.
+
+2. **Layout-tagged reinterpret / “view as” with checked algebra**  
+   Either: (a) a **`tile.view_as(other_tile_type, tile, proof_id)`** that is only legal when the compiler proves element count and alignment match, or (b) a **`tile.interleaved_view(tall_tile, K, TILE_COLS, MAX_GROUP_SIZE)`** that returns the `(K, ROW_BLOCK_COLS)` view with the **same** mapping as the reference kernel’s comments (tall row index formula). Goal: eliminate silent mismatch between manual mov loops and reshape.
+
+3. **Fused or batched column reduction API**  
+   A single op or macro region that applies **`TCOLSUM`-style reduction + epsilon + `TCOLEXPANDDIV`** over a list of same-shaped subviews, or over a user-described batch of `K×K` tiles in UB, to recover one-barrier amortization similar to C++ v2 without hand-writing MLIR.
+
+4. **Documented interaction: `reshape`, `SubTensorType`, and scratch**  
+   Formal rules (and diagnostics) for when **row-reduction scratch** and **column-reduction tmp** may alias the same UB buffer, and how **`tile.reshape`** affects those lifetimes. Today, accidental aliasing showed up as **NaNs** in generated C++; clearer IR invariants or automatic scratch splitting would help.
+
+5. **`pto.range` metadata: unroll / pipeline hints**  
+   Optional hints (unroll count, “emit static trip count when bounded by constant `min`”, affinity to reduction ops) so the lowering can match hand-tuned **`#pragma unroll`** and barrier placement in C++ v2’s tail loop.
+
+6. **Dynamic subview sizes where provably bounded**  
+   When a SSA value is bounded by a **compile-time constant** (e.g. `chunk_rows <= MAX_BATCH_ROWS` from `min_u(CHUNK, …)`), allow subview sizes to use that **constant upper bound** with **dynamic valid metadata**, reducing the need to always materialize full `MAX_BATCH_ROWS` paths in user code.
+
+---
+
+## Feature requests: `ptoas` (and related lowering)
+
+1. **`pto.tcolsum` tmp operand and `isBinary`**  
+   Document when `isBinary` is **required** vs optional for the tmp operand. If non-binary temps are valid on hardware for some reduction modes, allow them and surface **clear errors** when illegal; if they are never valid, document that so Python does not expose a dead `is_binary=False` path.
+
+2. **Scratch allocation / anti-aliasing for reshape + row ops**  
+   When analysis detects that **`TRESHAPE`** (or equivalent) overlaps **`TROWSUM` / `TROWMAX`** scratch in UB, **automatically** assign disjoint scratch (or emit a diagnostic with a fix hint), instead of silently aliasing (NaNs at runtime).
+
+3. **Barrier scheduling and reduction fusion**  
+   For patterns like “many `TCOLSUM` on disjoint `K×K` subviews of one parent tile in the same phase”, consider **fusing barriers**, **scheduling reductions back-to-back**, or **emitting one wider reduction** when legal—mirroring what a human does with a single interleaved `TCOLSUM` in C++ v2.
+
+4. **Lowering `tile.reshape` to strided copy when contiguous reinterpret is invalid**  
+   If the IR cannot prove that reshape is a no-op layout reinterpretation, **refuse** or **lower via explicit copy** with a reported cost estimate, so authors do not rely on accidental correctness.
+
+5. **Optional sync insertion policy per region**  
+   Finer control than a global `--enable-insert-sync`: e.g. “minimal barriers for this `vector_section`” vs “safe default”, to experiment with C++-style manual `pipe_barrier` placement without fighting the tool on every edit.
+
+---
+
+## What already works
+
+- The **batch-32 stack** large-`N` path in `sinkhorn_v2_builder.py` matches the reference in **`test_sinkhorn.py`** and improves somewhat over the 8-wide batched PTODSL kernel, but **GB/s remains far below C++ v2** on the same benchmark harness (`bench_sinkhorn_bandwidth.py`).
+
+---
+
+## References in this tree
+
+- PTODSL builder: `sinkhorn_v2_builder.py`  
+- Reference kernel and layout comments: `cpp_ref/kernel_sinkhorn_v2.cpp`  
+- Generated Ascend C++ (for inspecting barriers and op mix): `outputs/sinkhorn_v2_generated.cpp`

--- a/examples/aot/sinkhorn_demo/sinkhorn_batch8_builder.py
+++ b/examples/aot/sinkhorn_demo/sinkhorn_batch8_builder.py
@@ -1,0 +1,175 @@
+"""
+PTO-DSL builder for the fp16 Sinkhorn K=4 kernel with BATCH=8 stacked loads
+(`kernel_sinkhorn.cpp` in pto-kernels-sinkhorn-demo).
+
+Each vector core processes up to eight 4×4 matrices per group: one load / one
+store for the stack, batched row-wise ops (softmax, row-normalize), and a small
+loop for per-matrix column-normalize.
+"""
+
+from ptodsl import pto, tile, to_ir_module
+from ptodsl import scalar as s
+
+const = s.const
+
+K = 4
+TILE_DIM = 16
+BATCH = 8
+STACK_ROWS = BATCH * K  # 32
+
+
+def meta_data():
+    fp16 = pto.float16
+    fp32 = pto.float32
+    i32 = pto.int32
+    ptr_fp16 = pto.PtrType(fp16)
+    tensor2_fp16 = pto.TensorType(rank=2, dtype=fp16)
+    sub_stack_rk_fp16 = pto.SubTensorType(shape=[STACK_ROWS, K], dtype=fp16)
+
+    row_cfg = pto.TileBufConfig()
+    col_cfg = pto.TileBufConfig(blayout="ColMajor")
+
+    matrix_stack_fp16 = pto.TileBufType(
+        shape=[STACK_ROWS, TILE_DIM],
+        valid_shape=[-1, -1],
+        dtype=fp16,
+        memory_space="VEC",
+        config=row_cfg,
+    )
+
+    col_vec_stack_fp16 = pto.TileBufType(
+        shape=[STACK_ROWS, 1],
+        valid_shape=[-1, -1],
+        dtype=fp16,
+        memory_space="VEC",
+        config=col_cfg,
+    )
+
+    row_vec_fp16 = pto.TileBufType(
+        shape=[1, TILE_DIM],
+        valid_shape=[-1, -1],
+        dtype=fp16,
+        memory_space="VEC",
+        config=row_cfg,
+    )
+
+    return locals()
+
+
+@to_ir_module(meta_data=meta_data)
+def sinkhorn_k4_fp16(
+    input_ptr: "ptr_fp16",
+    output_ptr: "ptr_fp16",
+    num_matrices_i32: "i32",
+    repeat_i32: "i32",
+    eps: "fp32",
+) -> None:
+    c0 = const(0)
+    c1 = const(1)
+    cK = const(K)
+    cBATCH = const(BATCH)
+    f0 = const(0.0, s.float32)
+    f0_h = s.truncf(f0, s.float16)
+
+    nm = s.index_cast(num_matrices_i32)
+    repeat_idx = s.index_cast(repeat_i32)
+    eps_h = s.truncf(eps, s.float16)
+
+    with pto.vector_section():
+        cid = pto.get_block_idx()
+        sub_bid = pto.get_subblock_idx()
+        sub_bnum = pto.get_subblock_num()
+        num_blocks = pto.get_block_num()
+
+        wid = s.index_cast(cid * sub_bnum + sub_bid)
+        num_workers = s.index_cast(num_blocks * sub_bnum)
+
+        n_rows = nm * cK
+
+        tv_in = pto.as_tensor(
+            tensor2_fp16,
+            ptr=input_ptr,
+            shape=[n_rows, cK],
+            strides=[cK, c1],
+        )
+        tv_out = pto.as_tensor(
+            tensor2_fp16,
+            ptr=output_ptr,
+            shape=[n_rows, cK],
+            strides=[cK, c1],
+        )
+
+        stride_group = num_workers * cBATCH
+
+        for group in pto.range(wid * cBATCH, nm, stride_group):
+            nm_minus_g = nm - group
+            actual = s.min_u(cBATCH, nm_minus_g)
+            rows = actual * cK
+
+            row0 = group * cK
+
+            gm_in = pto.slice_view(
+                sub_stack_rk_fp16,
+                source=tv_in,
+                offsets=[row0, c0],
+                sizes=[rows, cK],
+            )
+            gm_out = pto.slice_view(
+                sub_stack_rk_fp16,
+                source=tv_out,
+                offsets=[row0, c0],
+                sizes=[rows, cK],
+            )
+
+            mat_stack = pto.alloc_tile(
+                matrix_stack_fp16, valid_row=rows, valid_col=cK
+            )
+            scratch_stack = pto.alloc_tile(
+                matrix_stack_fp16, valid_row=rows, valid_col=cK
+            )
+            row_stat = pto.alloc_tile(
+                col_vec_stack_fp16, valid_row=rows, valid_col=c1
+            )
+            col_stat = pto.alloc_tile(row_vec_fp16, valid_row=c1, valid_col=cK)
+
+            mat_wide = tile.subview(mat_stack, [c0, c0], [STACK_ROWS, TILE_DIM])
+            tile.muls(mat_wide, f0_h, mat_wide)
+
+            mat_rk = tile.subview(mat_stack, [c0, c0], [STACK_ROWS, K])
+            pto.load(gm_in, mat_rk)
+
+            tile.row_max(mat_stack, scratch_stack, row_stat)
+            tile.row_expand_sub(mat_stack, row_stat, mat_stack)
+            tile.exp(mat_stack, mat_stack)
+            tile.row_sum(mat_stack, scratch_stack, row_stat)
+            tile.row_expand_div(mat_stack, row_stat, mat_stack)
+
+            mat_eps = tile.subview(mat_stack, [c0, c0], [STACK_ROWS, TILE_DIM])
+            tile.adds(mat_eps, eps_h, mat_eps)
+
+            for m in pto.range(c0, actual, c1):
+                m_row = m * cK
+                mat_m = tile.subview(mat_stack, [m_row, c0], [K, K])
+                scratch_m = tile.subview(scratch_stack, [m_row, c0], [K, K])
+                tile.col_sum(mat_m, scratch_m, col_stat)
+                tile.adds(col_stat, eps_h, col_stat)
+                tile.col_expand_div(mat_m, col_stat, mat_m)
+
+            for _ in pto.range(c1, repeat_idx, c1):
+                tile.row_sum(mat_stack, scratch_stack, row_stat)
+                tile.adds(row_stat, eps_h, row_stat)
+                tile.row_expand_div(mat_stack, row_stat, mat_stack)
+
+                for m in pto.range(c0, actual, c1):
+                    m_row = m * cK
+                    mat_m = tile.subview(mat_stack, [m_row, c0], [K, K])
+                    scratch_m = tile.subview(scratch_stack, [m_row, c0], [K, K])
+                    tile.col_sum(mat_m, scratch_m, col_stat)
+                    tile.adds(col_stat, eps_h, col_stat)
+                    tile.col_expand_div(mat_m, col_stat, mat_m)
+
+            pto.store(mat_rk, gm_out)
+
+
+if __name__ == "__main__":
+    print(sinkhorn_k4_fp16)

--- a/examples/aot/sinkhorn_demo/sinkhorn_batch8_builder.py
+++ b/examples/aot/sinkhorn_demo/sinkhorn_batch8_builder.py
@@ -1,6 +1,6 @@
 """
 PTO-DSL builder for the fp16 Sinkhorn K=4 kernel with BATCH=8 stacked loads
-(`kernel_sinkhorn.cpp` in pto-kernels-sinkhorn-demo).
+(same algorithm as ``cpp_ref/kernel_sinkhorn.cpp`` in this demo).
 
 Each vector core processes up to eight 4×4 matrices per group: one load / one
 store for the stack, batched row-wise ops (softmax, row-normalize), and a small

--- a/examples/aot/sinkhorn_demo/sinkhorn_batch8_builder.py
+++ b/examples/aot/sinkhorn_demo/sinkhorn_batch8_builder.py
@@ -5,6 +5,10 @@ PTO-DSL builder for the fp16 Sinkhorn K=4 kernel with BATCH=8 stacked loads
 Each vector core processes up to eight 4×4 matrices per group: one load / one
 store for the stack, batched row-wise ops (softmax, row-normalize), and a small
 loop for per-matrix column-normalize.
+
+The Sinkhorn tail (``repeat - 1`` row/col iterations) is a **static** Python
+``range(1, repeat)`` so it unrolls at IR build time; ``repeat`` must match the
+host ``repeat_i32`` argument (10 in this demo).
 """
 
 from ptodsl import pto, tile, to_ir_module
@@ -16,6 +20,10 @@ K = 4
 TILE_DIM = 16
 BATCH = 8
 STACK_ROWS = BATCH * K  # 32
+
+# Static Sinkhorn outer iteration count for the tail loop (build-time unroll).
+# Host code must pass the same value as ``repeat_i32`` (this demo uses 10).
+repeat = 10
 
 
 def meta_data():
@@ -72,7 +80,6 @@ def sinkhorn_k4_fp16(
     f0_h = s.truncf(f0, s.float16)
 
     nm = s.index_cast(num_matrices_i32)
-    repeat_idx = s.index_cast(repeat_i32)
     eps_h = s.truncf(eps, s.float16)
 
     with pto.vector_section():
@@ -155,7 +162,7 @@ def sinkhorn_k4_fp16(
                 tile.adds(col_stat, eps_h, col_stat)
                 tile.col_expand_div(mat_m, col_stat, mat_m)
 
-            for _ in pto.range(c1, repeat_idx, c1):
+            for _ in range(1, repeat):
                 tile.row_sum(mat_stack, scratch_stack, row_stat)
                 tile.adds(row_stat, eps_h, row_stat)
                 tile.row_expand_div(mat_stack, row_stat, mat_stack)

--- a/examples/aot/sinkhorn_demo/sinkhorn_kernel_note.md
+++ b/examples/aot/sinkhorn_demo/sinkhorn_kernel_note.md
@@ -74,14 +74,16 @@ PyTorch does **stabilized softmax**: subtract row max, exponentiate, divide by r
 
 ### Loop: `for _ in range(repeat - 1):` row then column
 
-`pto.range(c1, repeat_idx, c1)` is the **runtime** loop over the iteration count (like Python `for _ in range(repeat - 1)` when tracing the IR). Each iteration does:
+In **`sinkhorn_k4_builder.py`**, `pto.range(c1, repeat_idx, c1)` is the **runtime** loop over the iteration count (like Python `for _ in range(repeat - 1)` when tracing the IR). In **`sinkhorn_batch8_builder.py`**, the same body is emitted with a **static** Python `for _ in range(1, repeat):` (`repeat = 10`) so the tail unrolls at IR build time; the host must still pass that same `repeat` value.
+
+Each iteration does:
 
 | PyTorch (one loop iteration) | PTO-DSL |
 |--------------------------------|---------|
 | `x / (x.sum(-1, ...) + eps)` | `row_sum` → `adds` on `row_stat` → `row_expand_div` |
 | `x / (x.sum(-2, ...) + eps)` | `col_sum` → `adds` on `col_stat` → `col_expand_div` |
 
-So the **body** of `pto.range(c1, repeat_idx, c1)` matches the **body** of the PyTorch `for` loop exactly: **row normalize, then column normalize**.
+So the **body** of that loop (whether `pto.range` or static `range`) matches the **body** of the PyTorch `for` loop exactly: **row normalize, then column normalize**.
 
 ### Writeback
 

--- a/examples/aot/sinkhorn_demo/sinkhorn_v2_builder.py
+++ b/examples/aot/sinkhorn_demo/sinkhorn_v2_builder.py
@@ -1,0 +1,267 @@
+"""
+PTO-DSL port of ``kernel_sinkhorn_v2.cpp`` (K=4, fp16).
+
+- **Total** ``N >= 2048`` matrices: **fast path** — same stacked pattern as
+  ``sinkhorn_batch8_builder.py`` with ``BATCH=32`` (128-row stack): row softmax
+  + row normalize on the stack, ``eps`` on the tile and in row/col sums like
+  the batched demo (the hand C++ v2 fast path elides some ``eps`` adds; this
+  port keeps them so the forward matches ``sinkhorn_normalize_ref`` under
+  ``test_sinkhorn.py``).
+- **Total** ``N < 2048`` matrices: **small path** — same per-matrix numerics as
+  ``sinkhorn_k4_builder.py`` (``eps`` after softmax and in sums).
+
+Static ``repeat=10`` (host must pass 10).
+"""
+
+from ptodsl import pto, tile, to_ir_module
+from ptodsl import scalar as s
+
+const = s.const
+
+K = 4
+TILE_COLS = 16
+# Matrices per chunk / stack height (32 matrices → 128 rows). Sized for UB.
+CHUNK_MATRICES = 32
+MAX_BATCH_ROWS = CHUNK_MATRICES * K
+
+repeat = 10
+N_FAST_THRESHOLD = 2048
+
+
+def meta_data():
+    fp16 = pto.float16
+    fp32 = pto.float32
+    i32 = pto.int32
+    ptr_fp16 = pto.PtrType(fp16)
+    tensor2_fp16 = pto.TensorType(rank=2, dtype=fp16)
+    sub_stack_rk_fp16 = pto.SubTensorType(shape=[MAX_BATCH_ROWS, K], dtype=fp16)
+
+    row_cfg = pto.TileBufConfig()
+    col_cfg = pto.TileBufConfig(blayout="ColMajor")
+
+    matrix_batch_fp16 = pto.TileBufType(
+        shape=[MAX_BATCH_ROWS, TILE_COLS],
+        valid_shape=[-1, -1],
+        dtype=fp16,
+        memory_space="VEC",
+        config=row_cfg,
+    )
+    col_vec_stack_fp16 = pto.TileBufType(
+        shape=[MAX_BATCH_ROWS, 1],
+        valid_shape=[-1, -1],
+        dtype=fp16,
+        memory_space="VEC",
+        config=col_cfg,
+    )
+    row_vec_fp16 = pto.TileBufType(
+        shape=[1, TILE_COLS],
+        valid_shape=[-1, -1],
+        dtype=fp16,
+        memory_space="VEC",
+        config=row_cfg,
+    )
+
+    matrix_kk_fp16 = pto.TileBufType(
+        shape=[TILE_COLS, TILE_COLS],
+        valid_shape=[TILE_COLS, TILE_COLS],
+        dtype=fp16,
+        memory_space="VEC",
+        config=row_cfg,
+    )
+    col_vec_k_fp16 = pto.TileBufType(
+        shape=[TILE_COLS, 1],
+        valid_shape=[-1, -1],
+        dtype=fp16,
+        memory_space="VEC",
+        config=col_cfg,
+    )
+    row_vec_k_fp16 = pto.TileBufType(
+        shape=[1, TILE_COLS],
+        valid_shape=[-1, -1],
+        dtype=fp16,
+        memory_space="VEC",
+        config=row_cfg,
+    )
+    sub_kk_fp16 = pto.SubTensorType(shape=[K, K], dtype=fp16)
+
+    return locals()
+
+
+@to_ir_module(meta_data=meta_data)
+def sinkhorn_v2_fp16(
+    input_ptr: "ptr_fp16",
+    output_ptr: "ptr_fp16",
+    num_matrices_i32: "i32",
+    repeat_i32: "i32",
+    eps: "fp32",
+) -> None:
+    c0 = const(0)
+    c1 = const(1)
+    cK = const(K)
+    cTILE = const(TILE_COLS)
+    c2048 = const(N_FAST_THRESHOLD)
+    f0 = const(0.0, s.float32)
+    f0_h = s.truncf(f0, s.float16)
+
+    nm = s.index_cast(num_matrices_i32)
+    eps_h = s.truncf(eps, s.float16)
+
+    with pto.vector_section():
+        cid = pto.get_block_idx()
+        sub_bid = pto.get_subblock_idx()
+        sub_bnum = pto.get_subblock_num()
+        num_blocks = pto.get_block_num()
+
+        wid = s.index_cast(cid * sub_bnum + sub_bid)
+        num_workers = s.index_cast(num_blocks * sub_bnum)
+
+        n_rows = nm * cK
+
+        tv_in = pto.as_tensor(
+            tensor2_fp16,
+            ptr=input_ptr,
+            shape=[n_rows, cK],
+            strides=[cK, c1],
+        )
+        tv_out = pto.as_tensor(
+            tensor2_fp16,
+            ptr=output_ptr,
+            shape=[n_rows, cK],
+            strides=[cK, c1],
+        )
+
+        with pto.if_context(s.ge(nm, c2048), has_else=True) as branch:
+
+            base_pw = s.div_s(nm, num_workers)
+            rem = s.rem_s(nm, num_workers)
+            my_first = wid * base_pw + s.select(s.lt(wid, rem), wid, rem)
+            my_count = base_pw + s.select(s.lt(wid, rem), c1, c0)
+
+            cCHUNK = const(CHUNK_MATRICES)
+
+            for chunk_off in pto.range(c0, my_count, cCHUNK):
+                chunk_left = my_count - chunk_off
+                chunk_mat = s.min_u(cCHUNK, chunk_left)
+                chunk_rows = chunk_mat * cK
+
+                row0 = my_first * cK + chunk_off * cK
+
+                gm_in = pto.slice_view(
+                    sub_stack_rk_fp16,
+                    source=tv_in,
+                    offsets=[row0, c0],
+                    sizes=[chunk_rows, cK],
+                )
+                gm_out = pto.slice_view(
+                    sub_stack_rk_fp16,
+                    source=tv_out,
+                    offsets=[row0, c0],
+                    sizes=[chunk_rows, cK],
+                )
+
+                mat_stack = pto.alloc_tile(
+                    matrix_batch_fp16, valid_row=chunk_rows, valid_col=cK
+                )
+                scratch_stack = pto.alloc_tile(
+                    matrix_batch_fp16, valid_row=chunk_rows, valid_col=cK
+                )
+                row_stat = pto.alloc_tile(
+                    col_vec_stack_fp16, valid_row=chunk_rows, valid_col=c1
+                )
+                col_stat = pto.alloc_tile(
+                    row_vec_fp16, valid_row=c1, valid_col=cK
+                )
+
+                mat_wide = tile.subview(
+                    mat_stack, [c0, c0], [MAX_BATCH_ROWS, TILE_COLS]
+                )
+                tile.muls(mat_wide, f0_h, mat_wide)
+                mat_rk = tile.subview(mat_stack, [c0, c0], [MAX_BATCH_ROWS, K])
+                pto.load(gm_in, mat_rk)
+
+                tile.row_max(mat_stack, scratch_stack, row_stat)
+                tile.row_expand_sub(mat_stack, row_stat, mat_stack)
+                tile.exp(mat_stack, mat_stack)
+                tile.row_sum(mat_stack, scratch_stack, row_stat)
+                tile.row_expand_div(mat_stack, row_stat, mat_stack)
+
+                mat_eps = tile.subview(
+                    mat_stack, [c0, c0], [MAX_BATCH_ROWS, TILE_COLS]
+                )
+                tile.adds(mat_eps, eps_h, mat_eps)
+
+                for m in pto.range(c0, chunk_mat, c1):
+                    m_row = m * cK
+                    mat_m = tile.subview(mat_stack, [m_row, c0], [K, K])
+                    scratch_m = tile.subview(scratch_stack, [m_row, c0], [K, K])
+                    tile.col_sum(mat_m, scratch_m, col_stat)
+                    tile.adds(col_stat, eps_h, col_stat)
+                    tile.col_expand_div(mat_m, col_stat, mat_m)
+
+                for _ in range(1, repeat):
+                    tile.row_sum(mat_stack, scratch_stack, row_stat)
+                    tile.adds(row_stat, eps_h, row_stat)
+                    tile.row_expand_div(mat_stack, row_stat, mat_stack)
+
+                    for m in pto.range(c0, chunk_mat, c1):
+                        m_row = m * cK
+                        mat_m = tile.subview(mat_stack, [m_row, c0], [K, K])
+                        scratch_m = tile.subview(
+                            scratch_stack, [m_row, c0], [K, K]
+                        )
+                        tile.col_sum(mat_m, scratch_m, col_stat)
+                        tile.adds(col_stat, eps_h, col_stat)
+                        tile.col_expand_div(mat_m, col_stat, mat_m)
+
+                pto.store(mat_rk, gm_out)
+
+        with branch.else_context():
+            mat_full = pto.alloc_tile(matrix_kk_fp16)
+            scratch_full = pto.alloc_tile(matrix_kk_fp16)
+            row_stat_s = pto.alloc_tile(
+                col_vec_k_fp16, valid_row=cK, valid_col=c1
+            )
+            col_stat_s = pto.alloc_tile(
+                row_vec_k_fp16, valid_row=c1, valid_col=cK
+            )
+            mat_kk = tile.subview(mat_full, [c0, c0], [K, K])
+            mat_eps_rows = tile.subview(mat_full, [c0, c0], [K, TILE_COLS])
+            scratch_kk = tile.subview(scratch_full, [c0, c0], [K, K])
+
+            for mi in pto.range(wid, nm, num_workers):
+                row0 = mi * cK
+                gm_in_s = pto.slice_view(
+                    sub_kk_fp16,
+                    source=tv_in,
+                    offsets=[row0, c0],
+                    sizes=[cK, cK],
+                )
+                gm_out_s = pto.slice_view(
+                    sub_kk_fp16,
+                    source=tv_out,
+                    offsets=[row0, c0],
+                    sizes=[cK, cK],
+                )
+                tile.muls(mat_full, f0_h, mat_full)
+                pto.load(gm_in_s, mat_kk)
+                tile.row_max(mat_kk, scratch_kk, row_stat_s)
+                tile.row_expand_sub(mat_kk, row_stat_s, mat_kk)
+                tile.exp(mat_kk, mat_kk)
+                tile.row_sum(mat_kk, scratch_kk, row_stat_s)
+                tile.row_expand_div(mat_kk, row_stat_s, mat_kk)
+                tile.adds(mat_eps_rows, eps_h, mat_eps_rows)
+                tile.col_sum(mat_kk, scratch_kk, col_stat_s)
+                tile.adds(col_stat_s, eps_h, col_stat_s)
+                tile.col_expand_div(mat_kk, col_stat_s, mat_kk)
+                for _ in range(1, repeat):
+                    tile.row_sum(mat_kk, scratch_kk, row_stat_s)
+                    tile.adds(row_stat_s, eps_h, row_stat_s)
+                    tile.row_expand_div(mat_kk, row_stat_s, mat_kk)
+                    tile.col_sum(mat_kk, scratch_kk, col_stat_s)
+                    tile.adds(col_stat_s, eps_h, col_stat_s)
+                    tile.col_expand_div(mat_kk, col_stat_s, mat_kk)
+                pto.store(mat_kk, gm_out_s)
+
+
+if __name__ == "__main__":
+    print(sinkhorn_v2_fp16)

--- a/examples/aot/sinkhorn_demo/sinkhorn_v2_builder.py
+++ b/examples/aot/sinkhorn_demo/sinkhorn_v2_builder.py
@@ -1,14 +1,15 @@
 """
 PTO-DSL port of ``kernel_sinkhorn_v2.cpp`` (K=4, fp16).
 
-- **Total** ``N >= 2048`` matrices: **fast path** — same stacked pattern as
-  ``sinkhorn_batch8_builder.py`` with ``BATCH=32`` (128-row stack): row softmax
-  + row normalize on the stack, ``eps`` on the tile and in row/col sums like
-  the batched demo (the hand C++ v2 fast path elides some ``eps`` adds; this
-  port keeps them so the forward matches ``sinkhorn_normalize_ref`` under
-  ``test_sinkhorn.py``).
-- **Total** ``N < 2048`` matrices: **small path** — same per-matrix numerics as
-  ``sinkhorn_k4_builder.py`` (``eps`` after softmax and in sums).
+**Large ``N`` (``>= 2048``):** batched fast path — up to **32** matrices per
+chunk (``128×16`` UB tile, same row packing as ``sinkhorn_batch8_builder.py``
+but ``BATCH=32``). One bulk load/store per chunk, batched row softmax on the
+``chunk_rows×K`` stack, then a short ``pto.range`` over matrices for
+``tile.col_sum`` + ``eps`` + divide. This avoids the hand-interleaved layout
+that must match ``tile.reshape`` byte-for-byte (a mismatch there produced
+NaNs); it still cuts GM traffic and row-op fusion versus the small-``N`` path.
+
+**Small ``N``:** same as ``sinkhorn_k4_builder.py`` (per-matrix, ``eps``).
 
 Static ``repeat=10`` (host must pass 10).
 """
@@ -20,9 +21,9 @@ const = s.const
 
 K = 4
 TILE_COLS = 16
-# Matrices per chunk / stack height (32 matrices → 128 rows). Sized for UB.
-CHUNK_MATRICES = 32
-MAX_BATCH_ROWS = CHUNK_MATRICES * K
+BATCH = 32
+MAX_BATCH_ROWS = BATCH * K  # 128
+CHUNK_MATRICES = BATCH
 
 repeat = 10
 N_FAST_THRESHOLD = 2048
@@ -39,7 +40,7 @@ def meta_data():
     row_cfg = pto.TileBufConfig()
     col_cfg = pto.TileBufConfig(blayout="ColMajor")
 
-    matrix_batch_fp16 = pto.TileBufType(
+    stack_fp16 = pto.TileBufType(
         shape=[MAX_BATCH_ROWS, TILE_COLS],
         valid_shape=[-1, -1],
         dtype=fp16,
@@ -53,7 +54,7 @@ def meta_data():
         memory_space="VEC",
         config=col_cfg,
     )
-    row_vec_fp16 = pto.TileBufType(
+    row_vec_k_fp16 = pto.TileBufType(
         shape=[1, TILE_COLS],
         valid_shape=[-1, -1],
         dtype=fp16,
@@ -75,13 +76,6 @@ def meta_data():
         memory_space="VEC",
         config=col_cfg,
     )
-    row_vec_k_fp16 = pto.TileBufType(
-        shape=[1, TILE_COLS],
-        valid_shape=[-1, -1],
-        dtype=fp16,
-        memory_space="VEC",
-        config=row_cfg,
-    )
     sub_kk_fp16 = pto.SubTensorType(shape=[K, K], dtype=fp16)
 
     return locals()
@@ -98,7 +92,6 @@ def sinkhorn_v2_fp16(
     c0 = const(0)
     c1 = const(1)
     cK = const(K)
-    cTILE = const(TILE_COLS)
     c2048 = const(N_FAST_THRESHOLD)
     f0 = const(0.0, s.float32)
     f0_h = s.truncf(f0, s.float16)
@@ -159,57 +152,61 @@ def sinkhorn_v2_fp16(
                     sizes=[chunk_rows, cK],
                 )
 
-                mat_stack = pto.alloc_tile(
-                    matrix_batch_fp16, valid_row=chunk_rows, valid_col=cK
+                mat_batch = pto.alloc_tile(
+                    stack_fp16, valid_row=chunk_rows, valid_col=cK
                 )
-                scratch_stack = pto.alloc_tile(
-                    matrix_batch_fp16, valid_row=chunk_rows, valid_col=cK
+                scratch_batch = pto.alloc_tile(
+                    stack_fp16, valid_row=chunk_rows, valid_col=cK
                 )
                 row_stat = pto.alloc_tile(
                     col_vec_stack_fp16, valid_row=chunk_rows, valid_col=c1
                 )
                 col_stat = pto.alloc_tile(
-                    row_vec_fp16, valid_row=c1, valid_col=cK
+                    row_vec_k_fp16, valid_row=c1, valid_col=cK
                 )
 
                 mat_wide = tile.subview(
-                    mat_stack, [c0, c0], [MAX_BATCH_ROWS, TILE_COLS]
+                    mat_batch, [c0, c0], [MAX_BATCH_ROWS, TILE_COLS]
                 )
                 tile.muls(mat_wide, f0_h, mat_wide)
-                mat_rk = tile.subview(mat_stack, [c0, c0], [MAX_BATCH_ROWS, K])
+                mat_rk = tile.subview(mat_batch, [c0, c0], [MAX_BATCH_ROWS, K])
                 pto.load(gm_in, mat_rk)
 
-                tile.row_max(mat_stack, scratch_stack, row_stat)
-                tile.row_expand_sub(mat_stack, row_stat, mat_stack)
-                tile.exp(mat_stack, mat_stack)
-                tile.row_sum(mat_stack, scratch_stack, row_stat)
-                tile.row_expand_div(mat_stack, row_stat, mat_stack)
+                tile.row_max(mat_batch, scratch_batch, row_stat)
+                tile.row_expand_sub(mat_batch, row_stat, mat_batch)
+                tile.exp(mat_batch, mat_batch)
+                tile.row_sum(mat_batch, scratch_batch, row_stat)
+                tile.row_expand_div(mat_batch, row_stat, mat_batch)
 
                 mat_eps = tile.subview(
-                    mat_stack, [c0, c0], [MAX_BATCH_ROWS, TILE_COLS]
+                    mat_batch, [c0, c0], [MAX_BATCH_ROWS, TILE_COLS]
                 )
                 tile.adds(mat_eps, eps_h, mat_eps)
 
                 for m in pto.range(c0, chunk_mat, c1):
                     m_row = m * cK
-                    mat_m = tile.subview(mat_stack, [m_row, c0], [K, K])
-                    scratch_m = tile.subview(scratch_stack, [m_row, c0], [K, K])
-                    tile.col_sum(mat_m, scratch_m, col_stat)
+                    mat_m = tile.subview(mat_batch, [m_row, c0], [K, K])
+                    scratch_m = tile.subview(
+                        scratch_batch, [m_row, c0], [K, K]
+                    )
+                    tile.col_sum(mat_m, scratch_m, col_stat, is_binary=True)
                     tile.adds(col_stat, eps_h, col_stat)
                     tile.col_expand_div(mat_m, col_stat, mat_m)
 
                 for _ in range(1, repeat):
-                    tile.row_sum(mat_stack, scratch_stack, row_stat)
+                    tile.row_sum(mat_batch, scratch_batch, row_stat)
                     tile.adds(row_stat, eps_h, row_stat)
-                    tile.row_expand_div(mat_stack, row_stat, mat_stack)
+                    tile.row_expand_div(mat_batch, row_stat, mat_batch)
 
                     for m in pto.range(c0, chunk_mat, c1):
                         m_row = m * cK
-                        mat_m = tile.subview(mat_stack, [m_row, c0], [K, K])
+                        mat_m = tile.subview(mat_batch, [m_row, c0], [K, K])
                         scratch_m = tile.subview(
-                            scratch_stack, [m_row, c0], [K, K]
+                            scratch_batch, [m_row, c0], [K, K]
                         )
-                        tile.col_sum(mat_m, scratch_m, col_stat)
+                        tile.col_sum(
+                            mat_m, scratch_m, col_stat, is_binary=True
+                        )
                         tile.adds(col_stat, eps_h, col_stat)
                         tile.col_expand_div(mat_m, col_stat, mat_m)
 
@@ -250,14 +247,16 @@ def sinkhorn_v2_fp16(
                 tile.row_sum(mat_kk, scratch_kk, row_stat_s)
                 tile.row_expand_div(mat_kk, row_stat_s, mat_kk)
                 tile.adds(mat_eps_rows, eps_h, mat_eps_rows)
-                tile.col_sum(mat_kk, scratch_kk, col_stat_s)
+                tile.col_sum(mat_kk, scratch_kk, col_stat_s, is_binary=True)
                 tile.adds(col_stat_s, eps_h, col_stat_s)
                 tile.col_expand_div(mat_kk, col_stat_s, mat_kk)
                 for _ in range(1, repeat):
                     tile.row_sum(mat_kk, scratch_kk, row_stat_s)
                     tile.adds(row_stat_s, eps_h, row_stat_s)
                     tile.row_expand_div(mat_kk, row_stat_s, mat_kk)
-                    tile.col_sum(mat_kk, scratch_kk, col_stat_s)
+                    tile.col_sum(
+                        mat_kk, scratch_kk, col_stat_s, is_binary=True
+                    )
                     tile.adds(col_stat_s, eps_h, col_stat_s)
                     tile.col_expand_div(mat_kk, col_stat_s, mat_kk)
                 pto.store(mat_kk, gm_out_s)

--- a/examples/aot/sinkhorn_demo/test_sinkhorn.py
+++ b/examples/aot/sinkhorn_demo/test_sinkhorn.py
@@ -1,8 +1,9 @@
 """
 Forward-only check: PTODSL-generated kernel vs ``sinkhorn_normalize_ref``.
 
-Tests both the batched stack-load kernel (``sinkhorn_batch8_builder.py``) and
-the naive per-matrix kernel (``sinkhorn_k4_builder.py``).
+Tests the batched stack-load kernel (``sinkhorn_batch8_builder.py``), the naive
+per-matrix kernel (``sinkhorn_k4_builder.py``), and the v2 port
+(``sinkhorn_v2_builder.py``).
 """
 
 import pytest
@@ -27,7 +28,7 @@ def device(npu_device):
     return npu_device
 
 
-@pytest.mark.parametrize("impl", ["batched", "naive"])
+@pytest.mark.parametrize("impl", ["batched", "naive", "v2"])
 @pytest.mark.parametrize("n0", [1, 2])
 @pytest.mark.parametrize("n1", [1, 1024, 4096])
 @pytest.mark.parametrize("mhc", [4])

--- a/examples/aot/sinkhorn_demo/test_sinkhorn.py
+++ b/examples/aot/sinkhorn_demo/test_sinkhorn.py
@@ -1,5 +1,8 @@
 """
 Forward-only check: PTODSL-generated kernel vs ``sinkhorn_normalize_ref``.
+
+Tests both the batched stack-load kernel (``sinkhorn_batch8_builder.py``) and
+the naive per-matrix kernel (``sinkhorn_k4_builder.py``).
 """
 
 import pytest
@@ -24,15 +27,18 @@ def device(npu_device):
     return npu_device
 
 
+@pytest.mark.parametrize("impl", ["batched", "naive"])
 @pytest.mark.parametrize("n0", [1, 2])
 @pytest.mark.parametrize("n1", [1, 1024, 4096])
 @pytest.mark.parametrize("mhc", [4])
-def test_sinkhorn_comprehensive(device, n0, n1, mhc):
+def test_sinkhorn_comprehensive(device, impl, n0, n1, mhc):
     torch.manual_seed(0)
     test_data = _generate(n0=n0, n1=n1, mhc=mhc, device=device)
     x = test_data["comb_res_mix"].clone()
 
-    out_pto = sinkhorn_normalize(x, test_data["repeat"], test_data["eps"])
+    out_pto = sinkhorn_normalize(
+        x, test_data["repeat"], test_data["eps"], impl=impl
+    )
     out_ref = sinkhorn_normalize_ref(x, test_data["repeat"], test_data["eps"])
 
     torch.testing.assert_close(out_pto, out_ref, rtol=1e-2, atol=1e-5)

--- a/examples/aot/sinkhorn_demo/tilelang_baseline/README.md
+++ b/examples/aot/sinkhorn_demo/tilelang_baseline/README.md
@@ -1,0 +1,32 @@
+# TileLang Sinkhorn baseline
+
+Self-contained TileLang (Ascend NPU) Sinkhorn normalization: stable softmax on the last axis, add `eps`, then alternating row/column scaling for `repeat` steps (reference helper `sinkhorn_normalize_ref` in `sinkhorn_kernel.py`).
+
+## Requirements
+
+- Python 3 with `torch` and `torch_npu`
+- `tilelang` built with Ascend NPU codegen enabled
+
+## Commands
+
+```bash
+cd tilelang_baseline
+python3 -m pytest test_sinkhorn.py -q
+python3 bench_sinkhorn.py --npu 0 --warmup 8 --iters 24 --repeat 10 --hc 4 --shapes 65536,262144
+```
+
+## Implementation notes
+
+- Inner TileLang steps follow the usual Sinkhorn pattern: numerically stable row-wise softmax, one column normalization, then repeated row/column normalizations (implemented with `T.reduce_*` and `T.tile.*` ops on a small `(hc, hc)` tile).
+- Each kernel launch handles at most **131070** matrices (`ceil(n/2)` grid slots). Larger batch counts are split across launches (`sinkhorn_normalize_tilelang`).
+
+## Sample bandwidth (this environment)
+
+Measured with `bench_sinkhorn.py` defaults (`repeat=10`, float32, effective GB/s = read+write tensor bytes / median latency):
+
+| Shape `(1, n1, 4, 4)` | Matrices | Median GB/s |
+|----------------------|----------|------------:|
+| n1 = 65536           | 65536    | 1.009       |
+| n1 = 262144          | 262144   | 1.067       |
+
+Hardware and driver versions differ; treat these as indicative only.

--- a/examples/aot/sinkhorn_demo/tilelang_baseline/bench_sinkhorn.py
+++ b/examples/aot/sinkhorn_demo/tilelang_baseline/bench_sinkhorn.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Median effective memory bandwidth (GB/s) for TileLang Sinkhorn forward (float32).
+
+Counts one read and one write of the flattened ``(n1, hc, hc)`` tensor per timed
+forward (``2 * n1 * hc * hc * sizeof(float)`` bytes), using the median wall-clock
+latency across ``--iters`` runs after ``--warmup``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+import torch
+
+_dir = Path(__file__).resolve().parent
+if str(_dir) not in sys.path:
+    sys.path.insert(0, str(_dir))
+
+import torch_npu  # noqa: E402, F401
+
+import tilelang  # noqa: E402
+from sinkhorn_kernel import build_sinkhorn, sinkhorn_normalize_tilelang  # noqa: E402
+
+
+def bandwidth_gbs(data_bytes: int, duration_us: float) -> float:
+    return (data_bytes / 1e9) / (duration_us / 1e6) if duration_us > 0 else 0.0
+
+
+def bench_tilelang_sinkhorn_gbs(
+    x: torch.Tensor,
+    repeat: int,
+    eps: float,
+    *,
+    hc: int,
+    warmup: int = 8,
+    iters: int = 24,
+) -> float:
+    """Median GB/s (decimal 1e9) for one forward (chunked launches if needed)."""
+    fn = build_sinkhorn(hc=hc, sinkhorn_iters=repeat, eps=eps)
+    x_flat = x.reshape(-1, hc, hc).contiguous()
+    out_flat = torch.empty_like(x_flat)
+    nmat = x_flat.shape[0]
+    elem_sz = x_flat.element_size()
+    bytes_rw = 2 * nmat * hc * hc * elem_sz
+
+    for _ in range(warmup):
+        sinkhorn_normalize_tilelang(
+            x_flat, hc=hc, sinkhorn_iters=repeat, eps=eps, _fn=fn, out=out_flat
+        )
+    torch.npu.synchronize()
+
+    times_us: list[float] = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        sinkhorn_normalize_tilelang(
+            x_flat, hc=hc, sinkhorn_iters=repeat, eps=eps, _fn=fn, out=out_flat
+        )
+        torch.npu.synchronize()
+        times_us.append((time.perf_counter() - t0) * 1e6)
+
+    times_us.sort()
+    med_us = times_us[len(times_us) // 2]
+    return bandwidth_gbs(bytes_rw, med_us)
+
+
+def _parse_npu(s: str) -> str:
+    t = s.strip().strip('"').strip("'")
+    if t.lower().startswith("npu:"):
+        return f"npu:{int(t.split(':', 1)[1])}"
+    return f"npu:{int(t)}"
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--npu", default="0", help="NPU index or npu:N (default: 0).")
+    p.add_argument("--warmup", type=int, default=8)
+    p.add_argument("--iters", type=int, default=24)
+    p.add_argument("--repeat", type=int, default=10, help="Sinkhorn iteration count.")
+    p.add_argument("--eps", type=float, default=1e-6)
+    p.add_argument("--hc", type=int, default=4, help="Inner Sinkhorn size (hc x hc).")
+    p.add_argument(
+        "--shapes",
+        type=str,
+        default="65536,262144",
+        help="Comma-separated n1 values for shape (1, n1, hc, hc).",
+    )
+    args = p.parse_args()
+
+    device = _parse_npu(args.npu)
+    torch.npu.set_device(device)
+    tilelang.disable_cache()
+
+    n1_list = [int(x.strip()) for x in args.shapes.split(",") if x.strip()]
+    hc = args.hc
+
+    print(
+        f"device={device} warmup={args.warmup} iters={args.iters} "
+        f"repeat={args.repeat} hc={hc} dtype=float32"
+    )
+    print("shape (matrices) | TileLang GB/s")
+    print("---|---:")
+
+    for n1 in n1_list:
+        torch.manual_seed(1)
+        x = torch.randn((1, n1, hc, hc), dtype=torch.float32, device=device)
+        bw = bench_tilelang_sinkhorn_gbs(
+            x,
+            args.repeat,
+            args.eps,
+            hc=hc,
+            warmup=args.warmup,
+            iters=args.iters,
+        )
+        print(f"(1, {n1}, {hc}, {hc}) ({n1} matrices) | {bw:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/aot/sinkhorn_demo/tilelang_baseline/conftest.py
+++ b/examples/aot/sinkhorn_demo/tilelang_baseline/conftest.py
@@ -1,0 +1,51 @@
+"""Local pytest hooks: NPU device selection for this directory only."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+_baseline_dir = Path(__file__).resolve().parent
+if str(_baseline_dir) not in sys.path:
+    sys.path.insert(0, str(_baseline_dir))
+
+
+def normalize_npu_device(device: str | int) -> str:
+    text = str(device).strip().strip('"').strip("'")
+    if text.lower().startswith("npu:"):
+        index = text.split(":", 1)[1].strip()
+    else:
+        index = text
+
+    if not index.isdigit():
+        raise ValueError(
+            f"Invalid NPU device '{device}'. Expected values like 0 or npu:0."
+        )
+    return f"npu:{int(index)}"
+
+
+def pytest_addoption(parser):
+    try:
+        parser.addoption(
+            "--npu",
+            action="store",
+            default="npu:0",
+            help="NPU device (examples: 0, npu:0, '0', 'npu:0').",
+        )
+    except ValueError as exc:
+        if "--npu" not in str(exc):
+            raise
+
+
+@pytest.fixture(scope="session")
+def npu_device(request):
+    raw = request.config.getoption("--npu")
+    return normalize_npu_device(raw)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_npu_device(npu_device):
+    torch.npu.set_device(npu_device)

--- a/examples/aot/sinkhorn_demo/tilelang_baseline/sinkhorn_kernel.py
+++ b/examples/aot/sinkhorn_demo/tilelang_baseline/sinkhorn_kernel.py
@@ -1,0 +1,139 @@
+# Copyright (c) Tile-AI Corporation.
+# SPDX-License-Identifier: MIT
+"""TileLang NPU kernel: Sinkhorn normalization (forward-only).
+
+Algorithm matches ``sinkhorn_normalize_ref`` in this file: stable softmax on the
+last axis, add ``eps``, then alternate row/column normalization for
+``sinkhorn_iters`` total steps (one column step after softmax, then pairs of
+row/column steps). The TileLang body uses shared-tile reductions and elementwise
+``T.tile`` ops analogous to a hand-written Sinkhorn loop on an ``(hc, hc)`` tile.
+"""
+
+from __future__ import annotations
+
+import tilelang
+import torch
+from tilelang import language as T
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+def sinkhorn_normalize_ref(
+    x: torch.Tensor, repeat: int = 10, eps: float = 1e-6
+) -> torch.Tensor:
+    """Reference Sinkhorn forward (PyTorch)."""
+    x = x.softmax(-1) + eps
+    x = x / (x.sum(-2, keepdim=True) + eps)
+    for _ in range(repeat - 1):
+        x = x / (x.sum(-1, keepdim=True) + eps)
+        x = x / (x.sum(-2, keepdim=True) + eps)
+    return x
+
+
+@tilelang.jit(out_idx=[1], pass_configs=pass_configs)
+def sinkhorn_normalize_kernel(hc: int, sinkhorn_iters: int, eps: float):
+    """JIT-compiled kernel: ``out[n, hc, hc] = sinkhorn(inp[n, hc, hc])``."""
+    n = T.symbolic("n")
+    dtype = "float"
+
+    block_M = 2
+    vec_num = 2
+    hc_pad = hc
+    if hc * 4 % 32 != 0:
+        hc_pad = tilelang.cdiv(hc * 4, 32) * 32 // 4
+
+    m_num = tilelang.cdiv(n, block_M)
+
+    @T.prim_func
+    def main(
+        inp: T.Tensor([n, hc, hc], dtype),
+        out: T.Tensor([n, hc, hc], dtype),
+    ):
+        with T.Kernel(m_num, is_npu=True) as (cid, vid):
+            comb_shared = T.alloc_shared((hc, hc_pad), dtype)
+            tmp_shared = T.alloc_shared(hc_pad, dtype)
+            row_sum = T.alloc_shared(hc_pad, dtype)
+            col_sum = T.alloc_shared(hc_pad, dtype)
+            row_max = T.alloc_shared(hc_pad, dtype)
+
+            gid = cid * block_M + vid * block_M // vec_num
+            if gid < n:
+                for i in T.serial(hc):
+                    T.copy(inp[gid, i, :], tmp_shared)
+                    T.copy(tmp_shared, comb_shared[i, :])
+
+                # comb = comb.softmax(-1) + eps
+                T.reduce_max(comb_shared, row_max, dim=-1, real_shape=[hc, hc])
+                for i in T.serial(hc):
+                    T.tile.sub(comb_shared[i, :], comb_shared[i, :], row_max[i])
+                T.tile.exp(comb_shared, comb_shared)
+                T.reduce_sum(comb_shared, row_sum, dim=-1, real_shape=[hc, hc])
+                for i in T.serial(hc):
+                    T.tile.div(comb_shared[i, :], comb_shared[i, :], row_sum[i])
+                T.tile.add(comb_shared, comb_shared, eps)
+
+                # comb = comb / (comb.sum(-2) + eps)
+                T.reduce_sum(comb_shared, col_sum, dim=0, real_shape=[hc, hc_pad])
+                T.tile.add(col_sum, col_sum, eps)
+                for i in T.serial(hc):
+                    T.tile.div(comb_shared[i, :], comb_shared[i, :], col_sum)
+
+                for _ in T.serial(sinkhorn_iters - 1):
+                    T.reduce_sum(comb_shared, row_sum, dim=-1, real_shape=[hc, hc])
+                    T.tile.add(row_sum, row_sum, eps)
+                    for i in T.serial(hc):
+                        T.tile.div(comb_shared[i, :], comb_shared[i, :], row_sum[i])
+                    T.reduce_sum(comb_shared, col_sum, dim=0, real_shape=[hc, hc_pad])
+                    T.tile.add(col_sum, col_sum, eps)
+                    for i in T.serial(hc):
+                        T.tile.div(comb_shared[i, :], comb_shared[i, :], col_sum)
+
+                for i in T.serial(hc):
+                    T.copy(comb_shared[i, :hc], out[gid, i, :])
+
+    return main
+
+
+def build_sinkhorn(hc: int = 4, sinkhorn_iters: int = 10, eps: float = 1e-6):
+    """Return compiled callable ``fn(inp) -> out`` (``inp`` is NPU float32)."""
+    return sinkhorn_normalize_kernel(hc, sinkhorn_iters, eps)
+
+
+# ``m_num = ceil(n / block_M)`` with ``block_M = 2`` must stay below the Ascend
+# launch grid limit (~65535); two matrices are scheduled per ``m_num`` slot
+# (``vec_num = 2``), so ``n <= 2 * 65535`` is safe for one launch.
+_MAX_N_SINGLE_LAUNCH = 2 * 65535
+
+
+def sinkhorn_normalize_tilelang(
+    inp: torch.Tensor,
+    *,
+    hc: int,
+    sinkhorn_iters: int = 10,
+    eps: float = 1e-6,
+    _fn=None,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run Sinkhorn on ``inp`` shaped ``[n, hc, hc]`` (float32 on NPU).
+
+    Large ``n`` are split into multiple kernel launches to respect grid limits.
+    """
+    if inp.dim() != 3 or inp.shape[1] != hc or inp.shape[2] != hc:
+        raise ValueError(f"expected [n, {hc}, {hc}], got {tuple(inp.shape)}")
+    n = inp.shape[0]
+    if out is None:
+        out = torch.empty_like(inp)
+    elif out.shape != inp.shape or out.dtype != inp.dtype:
+        raise ValueError("out must match inp shape and dtype")
+    fn = _fn or build_sinkhorn(hc, sinkhorn_iters, eps)
+    off = 0
+    while off < n:
+        m = min(_MAX_N_SINGLE_LAUNCH, n - off)
+        sl = slice(off, off + m)
+        out[sl] = fn(inp[sl])
+        off += m
+    return out

--- a/examples/aot/sinkhorn_demo/tilelang_baseline/test_sinkhorn.py
+++ b/examples/aot/sinkhorn_demo/tilelang_baseline/test_sinkhorn.py
@@ -1,0 +1,53 @@
+"""TileLang Sinkhorn kernel vs ``sinkhorn_normalize_ref`` (same directory)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+_dir = Path(__file__).resolve().parent
+if str(_dir) not in sys.path:
+    sys.path.insert(0, str(_dir))
+
+import tilelang  # noqa: E402
+import torch_npu  # noqa: F401, E402
+
+from sinkhorn_kernel import build_sinkhorn, sinkhorn_normalize_ref  # noqa: E402
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _tilelang_no_cache():
+    tilelang.disable_cache()
+    yield
+
+
+def _generate(n0: int, n1: int, mhc: int, device: str):
+    return {
+        "x": torch.randn((n0, n1, mhc, mhc), dtype=torch.float32, device=device),
+        "repeat": 10,
+        "eps": 1e-6,
+    }
+
+
+@pytest.mark.parametrize("n0", [1, 2])
+@pytest.mark.parametrize("n1", [1, 1024, 4096])
+@pytest.mark.parametrize("mhc", [4])
+def test_sinkhorn_tilelang_vs_ref(npu_device, n0, n1, mhc):
+    torch.manual_seed(0)
+    td = _generate(n0=n0, n1=n1, mhc=mhc, device=npu_device)
+    x = td["x"].clone()
+    nmat = n0 * n1
+    x_flat = x.reshape(nmat, mhc, mhc).contiguous()
+
+    fn = build_sinkhorn(hc=mhc, sinkhorn_iters=td["repeat"], eps=td["eps"])
+    out_flat = fn(x_flat)
+    torch.npu.synchronize()
+
+    ref = sinkhorn_normalize_ref(
+        x_flat.cpu(), td["repeat"], td["eps"]
+    ).to(device=npu_device, dtype=torch.float32)
+
+    torch.testing.assert_close(out_flat, ref, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
C++ v2 version now 5x faster than #120 

Blocker: The C++ version uses `TCopy` for stridded copy to "pre-align data" on UB, but ptoas lacks TCopyOp https://github.com/hw-native-sys/PTOAS/issues/575