### PR TITLE
Flash attention benchmarks for Sequence length 32k and 64k + upgrade to ptoas 0.31 and pto-isa latest commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,11 @@ jobs:
       image: quay.io/ascend/cann:8.5.0-910b-ubuntu22.04-py3.11
 
     env:
-      RELEASE_REPO: zhangstevenunity/PTOAS
-      RELEASE_VER: 0.29
-      RELEASE_TAG: v0.29
+      RELEASE_REPO: hw-native-sys/PTOAS
+      RELEASE_VER: 0.31
+      RELEASE_TAG: v0.31
       CLI_DIR: /installers/ptoas-cli
-      PTOISA_COMMIT: a9613ba881d926fc61f37d12f68658435f3bac9e
+      PTOISA_COMMIT: 0af942568a4f2868673da0a35b0f5b64f27a20d5
 
     steps:
       - name: Install system packages

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,8 +16,8 @@ RUN pip install --no-cache-dir \
     ipython jupyterlab matplotlib pandas
 
 # certain operations need latest isa header, not CANN 8.5.0 default
-# header on 2026/04/23
-ARG PTOISA_COMMIT=a9613ba881d926fc61f37d12f68658435f3bac9e
+# header on 2026/04/24
+ARG PTOISA_COMMIT=0af942568a4f2868673da0a35b0f5b64f27a20d5
 WORKDIR /sources
 RUN git clone https://gitcode.com/cann/pto-isa.git \
     && cd pto-isa && git checkout $PTOISA_COMMIT
@@ -30,7 +30,7 @@ ARG CACHE_BURST=1
 # ARG ARCH=x86_64
 ARG ARCH=aarch64
 ARG RELEASE_REPO=hw-native-sys/PTOAS
-ARG RELEASE_VER=0.29
+ARG RELEASE_VER=0.31
 ARG RELEASE_TAG=v${RELEASE_VER}
 ARG WHEEL_NAME=ptoas-${RELEASE_VER}-cp311-none-manylinux_2_34_${ARCH}.whl
 ARG CLI_TAR_NAME=ptoas-bin-${ARCH}.tar.gz

--- a/examples/aot/flash_attention/README.md
+++ b/examples/aot/flash_attention/README.md
@@ -1,8 +1,10 @@
 # Flash-Attention DSL kernel — feature gaps vs. `fa_performance_kernel.cpp`
 
 This folder contains a multi-pipe, software-pipelined Flash-Attention kernel
-written in pto-dsl. It currently reaches **0.94× of `npu_fused_infer_attention_score`**
-at `(Q_ROWS=2048, S1=8192, HEAD=32)` (185 µs vs 175 µs).
+written in pto-dsl. At `(Q_ROWS=2048, HEAD=32)` it reaches **0.97×** of
+`npu_fused_infer_attention_score` at S1=8k (178 µs vs 173 µs) and degrades to
+**0.73×** at S1=64k — the gap widens because most items below disable batched
+FFTS / wider K reuse that the reference uses to amortize vec work.
 
 ## Usage
 
@@ -19,31 +21,41 @@ ptoas / pto-dsl features needed to close the gap, ordered by impact.
 
 ---
 
-## 1. Sub-tile views on L1/L0/UB `TileBuf` — **biggest blocker**
+## 1. Sub-tile views on L1/L0/UB `TileBuf` — **partially supported**
 
-**Need:** a `pto.tile_subview(tile, offsets, sizes)` op returning a strided view
-into a sub-region of an existing `TileBuf` (analogous to `pto.slice_view` for GM
-tensors), plus a `tile.matmul` overload accepting a subview as its `out` operand.
+**Status:** ACC column subviews **work end-to-end** today via
+`tile.subview(acc_tile, offsets, sizes)` (lowered through ptoas + bisheng to a
+strided `Tile<Acc, ...>` view; experimentally validated in this kernel).
+**MAT and RIGHT** column subviews are still rejected by the ptoas verifier:
 
-**What it unlocks:** the reference's `kTileFactor = TILE_S1 / CUBE_S1 = 2`
-decomposition — one wide ACC tile filled by N narrower matmuls writing into
-column slices, then one push to vec:
+```
+'pto.subview' op boxed RowMajor subview must keep full cols
+```
+
+so the reference's "load wide K once, subview column halves on the RIGHT side"
+pattern still cannot be expressed. The workaround is to allocate N narrow
+RIGHT/MAT tiles and load each from its own GM `slice_view`, which adds MTE2
+traffic and forfeits MAT-side ping-pong on K.
+
+**Reference pattern (now expressible on the ACC side):**
 ```cpp
 TileBuf<S0, 256, fp32, ACC> qk_acc;
-matmul(q_left, k_right_lo, qk_acc[:, 0:128]);     // needs subview
-matmul(q_left, k_right_hi, qk_acc[:, 128:256]);   // needs subview
-tpush(qk_acc, qk_pipe);                           // single 256-wide push
+matmul(q_left, k_right_lo, qk_acc[:, 0:128]);     // ACC subview ✅
+matmul(q_left, k_right_hi, qk_acc[:, 128:256]);   // ACC subview ✅
+tpush(qk_acc, qk_pipe);                            // single 256-wide push
 ```
-Without it our cube-side `S1_TILE` is forced to equal `CUBE_S1`, so vec pays
-its per-tile overhead (softmax setup, FFTS acks, pipe push/pop sync) twice as
-often as the reference.
 
-**Underlying machinery:** `memref.subview` already works on
-`#pto.address_space<acc>` / `<vec>` / `<mat>` in MLIR — the codegen path exists.
-Only the Python wrapper + matmul-into-subview support are missing.
+**What's still missing:** lift the "must keep full cols" restriction for MAT
+and RIGHT memory spaces (or document why it's fundamental for boxed RowMajor
+layouts). Without this, the cube side cannot share one wide K-load across N
+narrow matmuls — defeating the main motivation for sub-tile views.
 
-**Expected impact:** ~2× vec amortization. Closes the largest single piece of
-the perf gap.
+**Empirical impact at our shape** (`S1_TILE=512`, `CUBE_S1=256`, `N_QK_SUB=2`):
+an ACC-subview-only experiment (with the MAT/RIGHT split workaround) ran at
+**~0.94×** of `npu_fused_attn` vs **~0.97×** for the wide single-matmul path now
+in tree. The ACC subview itself is free, but having to split the K-load (because
+MAT/RIGHT subviews are rejected) more than eats the gain. A real ~2× vec
+amortization would require the MAT/RIGHT verifier rule to be relaxed.
 
 ---
 

--- a/examples/aot/flash_attention/caller.cpp
+++ b/examples/aot/flash_attention/caller.cpp
@@ -15,7 +15,7 @@ extern "C" void call_kernel(
     uint8_t *q,
     uint8_t *k,     // K: [S1_TOTAL, HEAD] fp16
     uint8_t *v,
-    uint8_t *o)     // output [S0, HEAD] fp32
+    uint8_t *o)     // output O: [Q_ROWS, HEAD] fp32
 {
     void *fftsAddr = nullptr;
     uint32_t fftsLen = 0;

--- a/examples/aot/flash_attention/compile.sh
+++ b/examples/aot/flash_attention/compile.sh
@@ -1,40 +1,76 @@
 #!/usr/bin/env bash
 # Copyright (c) 2026 Huawei Technologies Co., Ltd.
 # CANN Open Software License Agreement Version 2.0
+#
+# AOT-compile the flash-attention kernel for one or more sequence lengths.
+#
+# Usage:
+#   bash compile.sh                    # build the default set: NUM_TILES = 16,32,64,128
+#                                      # -> fa.so, fa_32.so, fa_64.so, fa_128.so
+#                                      # (NUM_TILES=16 → 8k seqlen → fa.so)
+#   FA_TILES=16,64 bash compile.sh     # build only the listed NUM_TILES variants
+#   FA_TILES=16    bash compile.sh     # single-variant build (legacy behavior)
+#
+# Each NUM_TILES value N produces fa${TAG}.{mlir,cpp,so} where
+#   TAG = ""    if N == 16   (the builder's default → plain "fa.so")
+#   TAG = "_N"  otherwise.
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ARTIFACT_DIR="${SCRIPT_DIR}/build_artifacts"
-MLIR_PATH="${ARTIFACT_DIR}/fa.mlir"
-GENERATED_CPP="${ARTIFACT_DIR}/fa.cpp"
-LIB_PATH="${ARTIFACT_DIR}/fa.so"
-
 PTO_LIB_PATH="${PTO_LIB_PATH:-/sources/pto-isa}"
 
 mkdir -p "${ARTIFACT_DIR}"
-rm -f "${GENERATED_CPP}" "${LIB_PATH}"
 
-python "${SCRIPT_DIR}/kernels/fa_builder.py" > "${MLIR_PATH}"
-ptoas --pto-arch=a3 --enable-insert-sync "${MLIR_PATH}" > "${GENERATED_CPP}"
-# Per-block GM-slot partitioning is done in the DSL via pto.add_ptr in
-# call_both; no post-processing of the generated C++ needed.
+build_variant() {
+    local num_tiles="$1"
+    local tag
+    if [[ "${num_tiles}" == "16" ]]; then
+        tag=""
+    else
+        tag="_${num_tiles}"
+    fi
+    local mlir_path="${ARTIFACT_DIR}/fa${tag}.mlir"
+    local generated_cpp="${ARTIFACT_DIR}/fa${tag}.cpp"
+    local lib_path="${ARTIFACT_DIR}/fa${tag}.so"
 
-bisheng \
-    -I"${PTO_LIB_PATH}/include" \
-    -fPIC -shared -D_FORTIFY_SOURCE=2 -O2 -std=c++17 \
-    -Wno-macro-redefined -Wno-ignored-attributes -fstack-protector-strong \
-    -xcce -Xhost-start -Xhost-end \
-    -mllvm -cce-aicore-stack-size=0x8000 \
-    -mllvm -cce-aicore-function-stack-size=0x8000 \
-    -mllvm -cce-aicore-record-overflow=true \
-    -mllvm -cce-aicore-addr-transform \
-    -mllvm -cce-aicore-dcci-insert-for-scalar=false \
-    -cce-enable-mix \
-    --npu-arch=dav-2201 -DMEMORY_BASE \
-    -std=gnu++17 \
-    -DKERNEL_CPP="\"${GENERATED_CPP}\"" \
-    "${SCRIPT_DIR}/caller.cpp" \
-    -o "${LIB_PATH}"
+    echo "==> Building NUM_TILES=${num_tiles} -> $(basename "${lib_path}")"
+    rm -f "${mlir_path}" "${generated_cpp}" "${lib_path}"
 
-echo "Generated ${GENERATED_CPP}."
-echo "Built ${LIB_PATH}."
+    FA_NUM_TILES="${num_tiles}" \
+        python "${SCRIPT_DIR}/kernels/fa_builder.py" > "${mlir_path}"
+    ptoas --pto-arch=a3 --enable-insert-sync "${mlir_path}" > "${generated_cpp}"
+
+    bisheng \
+        -I"${PTO_LIB_PATH}/include" \
+        -fPIC -shared -D_FORTIFY_SOURCE=2 -O2 -std=c++17 \
+        -Wno-macro-redefined -Wno-ignored-attributes -fstack-protector-strong \
+        -xcce -Xhost-start -Xhost-end \
+        -mllvm -cce-aicore-stack-size=0x8000 \
+        -mllvm -cce-aicore-function-stack-size=0x8000 \
+        -mllvm -cce-aicore-record-overflow=true \
+        -mllvm -cce-aicore-addr-transform \
+        -mllvm -cce-aicore-dcci-insert-for-scalar=false \
+        -cce-enable-mix \
+        --npu-arch=dav-2201 -DMEMORY_BASE \
+        -std=gnu++17 \
+        -DKERNEL_CPP="\"${generated_cpp}\"" \
+        "${SCRIPT_DIR}/caller.cpp" \
+        -o "${lib_path}"
+
+    echo "    built ${lib_path}"
+}
+
+# Default tile set covers seqlen = NUM_TILES * S1_TILE = NUM_TILES * 512
+#   16 -> 8k, 32 -> 16k, 64 -> 32k, 128 -> 64k
+FA_TILES="${FA_TILES:-16,32,64,128}"
+
+IFS=',' read -r -a tile_list <<< "${FA_TILES}"
+for nt in "${tile_list[@]}"; do
+    nt_trim="$(echo "${nt}" | tr -d '[:space:]')"
+    [[ -z "${nt_trim}" ]] && continue
+    build_variant "${nt_trim}"
+done
+
+echo "Done. Built variants: ${FA_TILES}"

--- a/examples/aot/flash_attention/kernels/fa_builder.py
+++ b/examples/aot/flash_attention/kernels/fa_builder.py
@@ -1,4 +1,4 @@
-# Flash-Attention kernel builder – PERF VARIANT, ports the reference
+# Flash-Attention kernel builder. Ports the reference
 # `fa_performance_kernel.cpp` (a2a3) software-pipelined schedule onto the
 # pto-dsl multi-pipe primitives (ptoas >= 0.29).
 #
@@ -42,6 +42,7 @@ from ptodsl import pto, tile, to_ir_module
 from ptodsl import scalar as s
 
 import math
+import os
 
 const = s.const
 
@@ -51,20 +52,23 @@ const = s.const
 S0 = 32  # Q rows per block
 S0_HALF = S0 // 2  # rows per AIV sub-block
 HEAD = 32  # attention head dimension
-S1_TILE = 512  # K/V columns per tile  (perf4: same as perf3)
-NUM_TILES = 16  # number of K/V tiles  (S1_TOTAL = 512 * 16 = 8192)
+S1_TILE = 512  # K/V columns per tile
+# NUM_TILES is overridable via the FA_NUM_TILES env var so the same builder
+# can produce kernels for different sequence lengths
+# (S1_TOTAL = S1_TILE * NUM_TILES). 16 → 8k, 32 → 16k, 64 → 32k, 128 → 64k.
+# Constraint: (NUM_TILES - QK_PRELOAD) must be even (steady-state pair unroll).
+NUM_TILES = int(os.environ.get("FA_NUM_TILES", "16"))
 
 S1_TOTAL = S1_TILE * NUM_TILES
 
 Q_ROWS = 2048
 NUM_Q_BLOCKS = Q_ROWS // S0  # 64 row-blocks
 
-# QK preload depth — must be >= 1; reference uses 2.
-# With NUM_TILES=32 and QK_PRELOAD=2: vec pre-softmaxes tiles 0,1 then
-# steady-state loop interleaves softmax(t+2) with gu(t) for t=0..29, then
-# the epilogue does only gu(30), gu(31). NUM_TILES - QK_PRELOAD must be
-# even because we unroll the steady-state loop in pairs of 2 (for the
-# exp_max ring ping-pong). 32-2 = 30 ✓.
+# QK preload depth — must be >= 1; reference uses 2. The vec pre-softmaxes
+# tiles 0..QK_PRELOAD-1, then the steady-state loop interleaves softmax(t+QK_PRELOAD)
+# with gu(t), and the epilogue drains the last QK_PRELOAD gu's.
+# (NUM_TILES - QK_PRELOAD) must be even — steady state is pair-unrolled to
+# ping-pong the exp_max ring (see below).
 QK_PRELOAD = 2
 assert (
     NUM_TILES - QK_PRELOAD
@@ -78,11 +82,11 @@ SLOT_SIZE_P = S0 * S1_TILE * 2  # fp16 P matrix sent vec → cube
 
 # `dir_mask = 1/2` always lowers to slot_num = 8 on a3 (design doc §4.4).
 SLOT_NUM = 8
-# perf4: kept at 1 — bumping to 2 overflows VEC UB at S1_TILE=512.
+# Kept at 1: bumping to 2 overflows VEC UB at S1_TILE=512.
 QK_LOCAL_SLOT_NUM = 1
-# perf4: PV converted from legacy aic/aiv_initialize_pipe to lower-level
-# l2g2l_pipe with local_slot_num=1 (legacy ops force local = SLOT_NUM=8
-# = 32 KB). With local=1 the PV vec fifo is just 4 KB.
+# PV uses lower-level l2g2l_pipe with local_slot_num=1; the legacy
+# aic/aiv_initialize_pipe path forces local = SLOT_NUM = 8 (32 KB MAT)
+# whereas local=1 here is just 4 KB.
 PV_LOCAL_SLOT_NUM = 1
 
 # GM-staged FIFO bytes / fp32 elements per AIC block.
@@ -257,18 +261,10 @@ def module():
             nosplit=False,
         )
 
-        # Ping-pong (NB=2) every cube tile-buffer that crosses an iteration
-        # boundary. The MTE2 load of buffer[t+1] runs concurrently with the
-        # MTE1 / M of buffer[t].
-        # NOTE perf3: RIGHT memspace is only 64 KB. With S1_TILE=512 each
-        # k_right/v_right = 32 KB so we cannot ping-pong them (would need
-        # 128 KB total). MAT-side ping-pong (k_mat/v_mat) still gives
-        # MTE2/MTE1 overlap; the RIGHT mov is short.
-        # perf3: cube buffers reverted to single-buffered (no NB ping-pong).
-        # At S1_TILE=512 the L1 budgets cannot fit 2x ping-pong of all stages
-        # (RIGHT 64 KB; ACC; LEFT). The whole point of perf3 is to test
-        # whether vec is the bottleneck via larger S1_TILE — cube ping-pong
-        # was already shown not to help (perf vs perf2 = flat).
+        # All cube tile-buffers are single-buffered: at S1_TILE=512 the
+        # RIGHT space (64 KB) cannot host a ping-pong (k_right + v_right
+        # are 32 KB each), and earlier experiments showed cube-side
+        # ping-pong gives no measurable speedup once vec is the bottleneck.
         q_mat = pto.alloc_tile(q_mat_ty)
         q_left = pto.alloc_tile(q_left_ty)
         k_mat_s = pto.alloc_tile(k_mat_ty)
@@ -279,8 +275,8 @@ def module():
         v_mat_s = pto.alloc_tile(v_mat_ty)
         v_right_s = pto.alloc_tile(v_right_ty)
         pv_acc_s = pto.alloc_tile(pv_acc_ty)
-        # Aliasing wrappers so the rest of the cube body keeps the perf2
-        # `[buf]` indexing pattern.
+        # Aliasing wrappers: keep the per-iteration `[buf]` indexing pattern
+        # in the body even though all slots currently point at one alloc.
         k_mat = [k_mat_s, k_mat_s]
         k_right = [k_right_s, k_right_s]
         qk_acc = [qk_acc_s, qk_acc_s]

--- a/examples/aot/flash_attention/run.py
+++ b/examples/aot/flash_attention/run.py
@@ -2,10 +2,13 @@
 # Copyright (c) 2026 Huawei Technologies Co., Ltd.
 # CANN Open Software License Agreement Version 2.0
 #
-# Runner for the multi-pipe FA builder. Differences vs run.py:
-#   * Uses the multi-pipe .so (built by compile.sh).
-#   * Pulls per-block GM size from kernels/fa_builder.GM_ELEMS_PER_BLOCK
-#     (3 separate pipes → 425 984 B/block instead of 262 144 B/block).
+# AOT runner for the multi-pipe FA builder. All .so variants must be built
+# beforehand by `bash compile.sh` (which produces fa.so, fa_32.so, fa_64.so,
+# fa_128.so by default). This script only loads and invokes them.
+#
+#   * Correctness check: the default 8k variant (fa.so).
+#   * Benchmark: 8k / 16k / 32k / 64k variants by default. Override with
+#     FA_BENCH_LENGTHS=8192,32768 (each length must be a multiple of S1_TILE).
 
 import ctypes
 import os
@@ -17,32 +20,61 @@ import torch_npu  # noqa: F401
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(THIS_DIR, "kernels"))
-from fa_builder import (  # noqa: E402
-    GM_ELEMS_PER_BLOCK,
-    HEAD,
-    NUM_Q_BLOCKS,
-    NUM_TILES,
-    Q_ROWS,
-    S0,
-    S1_TILE,
-    S1_TOTAL,
-)
+import fa_builder  # noqa: E402
 
 from ptodsl import do_bench  # noqa: E402
 from ptodsl.utils.npu_info import get_num_cube_cores, get_test_device  # noqa: E402
 
-DEFAULT_LIB_PATH = os.path.join(THIS_DIR, "build_artifacts", "fa.so")
+ARTIFACT_DIR = os.path.join(THIS_DIR, "build_artifacts")
+
+# Sequence lengths benchmarked. Override with
+#   FA_BENCH_LENGTHS=8192,32768
+# Each must be a multiple of S1_TILE (=512) and have a matching prebuilt .so.
+DEFAULT_BENCH_LENGTHS = (8192, 16384, 32768, 65536)
+
+
+def _parse_bench_lengths():
+    raw = os.environ.get("FA_BENCH_LENGTHS")
+    if not raw:
+        return DEFAULT_BENCH_LENGTHS
+    return tuple(int(x) for x in raw.split(",") if x.strip())
+
 
 ATOL = 1e-3
 RTOL = 1e-3
 
 
 def get_block_dim() -> int:
-    return min(NUM_Q_BLOCKS, get_num_cube_cores())
+    return min(fa_builder.NUM_Q_BLOCKS, get_num_cube_cores())
 
 
 def get_slot_elems(block_dim: int) -> int:
-    return GM_ELEMS_PER_BLOCK * block_dim
+    return fa_builder.GM_ELEMS_PER_BLOCK * block_dim
+
+
+def num_tiles_for(seq_len: int) -> int:
+    s1_tile = fa_builder.S1_TILE
+    if seq_len % s1_tile != 0:
+        raise ValueError(f"seq_len {seq_len} not divisible by S1_TILE={s1_tile}")
+    return seq_len // s1_tile
+
+
+def lib_path_for(num_tiles: int) -> str:
+    # NUM_TILES=16 is the builder default and produces plain fa.so.
+    if num_tiles == 16:
+        return os.path.join(ARTIFACT_DIR, "fa.so")
+    return os.path.join(ARTIFACT_DIR, f"fa_{num_tiles}.so")
+
+
+def require_lib(num_tiles: int) -> str:
+    """Return the prebuilt .so path for the variant, or raise."""
+    lib_path = lib_path_for(num_tiles)
+    if not os.path.exists(lib_path):
+        raise FileNotFoundError(
+            f"Missing prebuilt kernel: {lib_path}\n"
+            f"Run `bash compile.sh` (or `FA_TILES={num_tiles} bash compile.sh`) first."
+        )
+    return lib_path
 
 
 def torch_to_ctypes(t: torch.Tensor) -> ctypes.c_void_p:
@@ -87,6 +119,12 @@ def fused_attention(q, k, v, is_causal=False):
 
 def test_flash(lib, device):
     torch.manual_seed(0)
+    Q_ROWS = fa_builder.Q_ROWS
+    HEAD = fa_builder.HEAD
+    S1_TOTAL = fa_builder.S1_TOTAL
+    NUM_TILES = fa_builder.NUM_TILES
+    GM_ELEMS_PER_BLOCK = fa_builder.GM_ELEMS_PER_BLOCK
+
     block_dim = get_block_dim()
     slot_elems = get_slot_elems(block_dim)
 
@@ -119,14 +157,20 @@ def test_flash(lib, device):
     )
 
 
-def benchmark_flash(lib, device, warmup=10, iters=100):
+def benchmark_flash(lib, device, num_tiles, warmup=10, iters=100):
+    """Benchmark a single (length-tagged) .so. Returns dict of metrics."""
     torch.manual_seed(0)
+    Q_ROWS = fa_builder.Q_ROWS
+    HEAD = fa_builder.HEAD
+    S1_TILE = fa_builder.S1_TILE
+    s1_total = S1_TILE * num_tiles
+
     block_dim = get_block_dim()
     slot_elems = get_slot_elems(block_dim)
 
     q = torch.randn((Q_ROWS, HEAD), dtype=torch.float16, device=device)
-    k = torch.randn((S1_TOTAL, HEAD), dtype=torch.float16, device=device)
-    v = torch.randn((S1_TOTAL, HEAD), dtype=torch.float16, device=device)
+    k = torch.randn((s1_total, HEAD), dtype=torch.float16, device=device)
+    v = torch.randn((s1_total, HEAD), dtype=torch.float16, device=device)
 
     gm_slot = torch.zeros((slot_elems,), dtype=torch.float32, device=device)
     o = torch.zeros((Q_ROWS, HEAD), dtype=torch.float32, device=device)
@@ -153,6 +197,9 @@ def benchmark_flash(lib, device, warmup=10, iters=100):
         run_reference, warmup_iters=warmup, benchmark_iters=iters, unit="us"
     )
 
+    # One untimed correctness check per length: assert against the fp32
+    # reference so silent miscompiles fail loudly instead of just showing
+    # a large max|err| in the summary table.
     run_kernel()
     torch.npu.synchronize()
     o_kernel = o.clone()
@@ -160,40 +207,69 @@ def benchmark_flash(lib, device, warmup=10, iters=100):
     torch.npu.synchronize()
     o_golden = fa_reference(q, k, v)
 
-    diff_kernel = (o_kernel.cpu().float() - o_golden.cpu()).abs()
-    diff_fused = (o_fused.cpu().float() - o_golden.cpu()).abs()
-
+    diff_kernel = (o_kernel.cpu().float() - o_golden.cpu()).abs().max().item()
+    diff_fused = (o_fused.cpu().float() - o_golden.cpu()).abs().max().item()
     torch.testing.assert_close(
         o_kernel.cpu().float(), o_golden.cpu(), rtol=RTOL, atol=ATOL
     )
 
-    flops = 4 * Q_ROWS * HEAD * S1_TOTAL
-    print(f"\n{'Benchmark (fa)':=^60}")
-    print(f"  q_rows={Q_ROWS}  s1={S1_TOTAL}  head={HEAD}  tiles={NUM_TILES}")
+    flops = 4 * Q_ROWS * HEAD * s1_total
+    return {
+        "seq_len": s1_total,
+        "num_tiles": num_tiles,
+        "block_dim": block_dim,
+        "kernel_us": kernel_us,
+        "ref_us": ref_us,
+        "kernel_gflops": flops / (kernel_us * 1e-6) / 1e9,
+        "ref_gflops": flops / (ref_us * 1e-6) / 1e9,
+        "speedup": ref_us / kernel_us,
+        "kernel_max_err": diff_kernel,
+        "fused_max_err": diff_fused,
+    }
+
+
+def print_bench_row(r):
     print(
-        f"  blockDim={block_dim}  Q-blocks={NUM_Q_BLOCKS}  cores={get_num_cube_cores()}"
+        f"  s1={r['seq_len']:>6}  tiles={r['num_tiles']:>3}  "
+        f"fa={r['kernel_us']:8.2f} us ({r['kernel_gflops']:7.1f} GF/s)  "
+        f"ref={r['ref_us']:8.2f} us ({r['ref_gflops']:7.1f} GF/s)  "
+        f"speedup={r['speedup']:.2f}x  "
+        f"err: ours={r['kernel_max_err']:.2e} ref={r['fused_max_err']:.2e}"
     )
-    print(f"  warmup={warmup}  iters={iters}")
-    print(
-        f"  fa:         {kernel_us:8.2f} us  ({flops / (kernel_us * 1e-6) / 1e9:.2f} GFLOP/s)"
-    )
-    print(
-        f"  npu_fused_attn: {ref_us:8.2f} us  ({flops / ( ref_us * 1e-6) / 1e9:.2f} GFLOP/s)"
-    )
-    print(f"  speedup vs npu_fused_attn: {ref_us / kernel_us:.2f}x")
-    print(
-        f"  accuracy: kernel max|err|={diff_kernel.max():.2e}  "
-        f"npu_fused max|err|={diff_fused.max():.2e}"
-    )
-    print(f"{'':=^60}")
 
 
 def main():
     device = get_test_device()
     torch.npu.set_device(device)
-    lib = load_lib(DEFAULT_LIB_PATH)
-    test_flash(lib, device)
-    benchmark_flash(lib, device)
+
+    bench_lengths = _parse_bench_lengths()
+
+    # Verify all required .so artifacts exist before doing anything.
+    required = [(seq_len, num_tiles_for(seq_len)) for seq_len in bench_lengths]
+    for seq_len, nt in required:
+        require_lib(nt)
+
+    # ---- correctness on default 8k variant ----
+    default_lib = load_lib(require_lib(16))
+    test_flash(default_lib, device)
+
+    # ---- benchmark across requested sequence lengths ----
+    print(f"\n{'Benchmark (fa)':=^96}")
+    print(
+        f"  Q_ROWS={fa_builder.Q_ROWS}  HEAD={fa_builder.HEAD}  "
+        f"S1_TILE={fa_builder.S1_TILE}  "
+        f"NUM_Q_BLOCKS={fa_builder.NUM_Q_BLOCKS}  cores={get_num_cube_cores()}"
+    )
+    print(f"  lengths: {list(bench_lengths)}")
+    print("-" * 96)
+
+    results = []
+    for seq_len, nt in required:
+        lib = load_lib(require_lib(nt))
+        r = benchmark_flash(lib, device, num_tiles=nt)
+        print_bench_row(r)
+        results.append(r)
+    print("=" * 96)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
```bash
=========================================Benchmark (fa)=========================================
  Q_ROWS=2048  HEAD=32  S1_TILE=512  NUM_Q_BLOCKS=64  cores=24
  lengths: [8192, 16384, 32768, 65536]
------------------------------------------------------------------------------------------------
  s1=  8192  tiles= 16  fa=  171.99 us (12485.8 GF/s)  ref=  175.05 us (12267.8 GF/s)  speedup=1.02x  err: ours=1.79e-05 ref=3.46e-05
  s1= 16384  tiles= 32  fa=  361.87 us (11868.7 GF/s)  ref=  295.65 us (14527.0 GF/s)  speedup=0.82x  err: ours=1.33e-05 ref=2.11e-05
  s1= 32768  tiles= 64  fa=  713.39 us (12041.1 GF/s)  ref=  537.82 us (15971.8 GF/s)  speedup=0.75x  err: ours=9.39e-06 ref=1.71e-05
  s1= 65536  tiles=128  fa= 1425.26 us (12053.8 GF/s)  ref= 1023.22 us (16790.1 GF/s)  speedup=0.72x  err: ours=6.21e-06 ref=1.22e-05
================================================================================================
```